### PR TITLE
feat: add thread reply functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ slack-cli send -c general -m "Line 1\nLine 2\nLine 3"
 
 # Send message from file
 slack-cli send -c random -f message.txt
+
+# Reply to a thread
+slack-cli send -c channel-name -m "Reply message" --thread 1719207629.000100
+
+# Reply to a thread (short option)
+slack-cli send -c channel-name -m "Reply message" -t 1719207629.000100
 ```
 
 ### List Channels
@@ -160,6 +166,7 @@ slack-cli config set --token NEW_TOKEN
 | --channel | -c | Target channel name or ID (required) |
 | --message | -m | Message to send |
 | --file | -f | File containing message content |
+| --thread | -t | Thread timestamp to reply to |
 
 ### channels command
 | Option | Short | Description |

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -8,12 +8,19 @@ import { SendOptions } from '../types/commands';
 import { extractErrorMessage } from '../utils/error-utils';
 import * as fs from 'fs/promises';
 
+function isValidThreadTimestamp(timestamp: string): boolean {
+  // Slack timestamp format: 1234567890.123456
+  const timestampRegex = /^\d{10}\.\d{6}$/;
+  return timestampRegex.test(timestamp);
+}
+
 export function setupSendCommand(): Command {
   const sendCommand = new Command('send')
     .description('Send a message to a Slack channel')
     .requiredOption('-c, --channel <channel>', 'Target channel name or ID')
     .option('-m, --message <message>', 'Message to send')
     .option('-f, --file <file>', 'File containing message content')
+    .option('-t, --thread <thread>', 'Thread timestamp to reply to')
     .option('--profile <profile>', 'Use specific workspace profile')
     .hook('preAction', (thisCommand) => {
       const options = thisCommand.opts();
@@ -22,6 +29,9 @@ export function setupSendCommand(): Command {
       }
       if (options.message && options.file) {
         thisCommand.error(`Error: ${ERROR_MESSAGES.BOTH_MESSAGE_AND_FILE}`);
+      }
+      if (options.thread && !isValidThreadTimestamp(options.thread)) {
+        thisCommand.error('Error: Invalid thread timestamp format');
       }
     })
     .action(
@@ -42,7 +52,7 @@ export function setupSendCommand(): Command {
 
         // Send message
         const client = await createSlackClient(options.profile);
-        await client.sendMessage(options.channel, messageContent);
+        await client.sendMessage(options.channel, messageContent, options.thread);
 
         console.log(chalk.green(`✓ ${SUCCESS_MESSAGES.MESSAGE_SENT(options.channel)}`));
       })

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -19,6 +19,7 @@ export interface SendOptions {
   channel: string;
   message?: string;
   file?: string;
+  thread?: string;
   profile?: string;
 }
 

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -77,8 +77,8 @@ export class SlackApiClient {
     this.messageOps = new MessageOperations(token);
   }
 
-  async sendMessage(channel: string, text: string): Promise<ChatPostMessageResponse> {
-    return this.messageOps.sendMessage(channel, text);
+  async sendMessage(channel: string, text: string, thread_ts?: string): Promise<ChatPostMessageResponse> {
+    return this.messageOps.sendMessage(channel, text, thread_ts);
   }
 
   async listChannels(options: ListChannelsOptions): Promise<Channel[]> {

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -14,11 +14,17 @@ export class MessageOperations extends BaseSlackClient {
     this.channelOps = new ChannelOperations(token);
   }
 
-  async sendMessage(channel: string, text: string): Promise<ChatPostMessageResponse> {
-    return await this.client.chat.postMessage({
+  async sendMessage(channel: string, text: string, thread_ts?: string): Promise<ChatPostMessageResponse> {
+    const params: any = {
       channel,
       text,
-    });
+    };
+    
+    if (thread_ts) {
+      params.thread_ts = thread_ts;
+    }
+    
+    return await this.client.chat.postMessage(params);
   }
 
   async getHistory(channel: string, options: HistoryOptions): Promise<HistoryResult> {

--- a/tests/commands/send.test.ts
+++ b/tests/commands/send.test.ts
@@ -47,7 +47,7 @@ describe('send command', () => {
 
       await program.parseAsync(['node', 'slack-cli', 'send', '-c', 'general', '-m', 'Hello, World!']);
 
-      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith('general', 'Hello, World!');
+      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith('general', 'Hello, World!', undefined);
       expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining(SUCCESS_MESSAGES.MESSAGE_SENT('general')));
     });
 
@@ -84,7 +84,55 @@ describe('send command', () => {
       await program.parseAsync(['node', 'slack-cli', 'send', '-c', 'general', '-f', 'message.txt']);
 
       expect(fs.readFile).toHaveBeenCalledWith('message.txt', 'utf-8');
-      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith('general', fileContent);
+      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith('general', fileContent, undefined);
+    });
+  });
+
+  describe('send reply to thread', () => {
+    it('should send a reply to a thread with --thread option', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString()
+      });
+      vi.mocked(mockSlackClient.sendMessage).mockResolvedValue({
+        ok: true,
+        ts: '1234567890.123456'
+      });
+
+      await program.parseAsync(['node', 'slack-cli', 'send', '-c', 'general', '-m', 'Reply to thread', '--thread', '1719207629.000100']);
+
+      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith('general', 'Reply to thread', '1719207629.000100');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining(SUCCESS_MESSAGES.MESSAGE_SENT('general')));
+    });
+
+    it('should send a reply to a thread with -t option', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString()
+      });
+      vi.mocked(mockSlackClient.sendMessage).mockResolvedValue({
+        ok: true,
+        ts: '1234567890.123456'
+      });
+
+      await program.parseAsync(['node', 'slack-cli', 'send', '-c', 'general', '-m', 'Reply to thread', '-t', '1719207629.000100']);
+
+      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith('general', 'Reply to thread', '1719207629.000100');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining(SUCCESS_MESSAGES.MESSAGE_SENT('general')));
+    });
+
+    it('should validate thread timestamp format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString()
+      });
+
+      const sendCommand = setupSendCommand();
+      sendCommand.exitOverride();
+
+      await expect(
+        sendCommand.parseAsync(['-c', 'general', '-m', 'Reply', '-t', 'invalid-timestamp'], { from: 'user' })
+      ).rejects.toThrow('Invalid thread timestamp format');
     });
   });
 


### PR DESCRIPTION
## Summary
- Added thread reply functionality to the `send` command
- Users can now reply to existing Slack threads using the `--thread` or `-t` option
- Thread timestamp validation ensures proper format (10digits.6digits)

## Changes
- Added `--thread`/`-t` option to send command
- Updated SlackApiClient and MessageOperations to support thread_ts parameter
- Added comprehensive tests for thread reply functionality
- Updated README with usage examples

## Usage
```bash
# Reply to a thread
slack-cli send -c channel-name -m "Reply message" --thread 1719207629.000100

# Short option
slack-cli send -c channel-name -m "Reply message" -t 1719207629.000100
```

## Test plan
- [x] Unit tests for thread reply functionality
- [x] Thread timestamp validation tests
- [x] All existing tests still pass
- [x] Linting passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/code)