### PR TITLE
fix: npm publishでbinエントリが削除される問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,11 @@
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {
-    "slack-cli": "./dist/index.js"
+    "slack-cli": "dist/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "ts-node src/index.ts",


### PR DESCRIPTION
# 背景

- `npm publish` 実行時に `bin[slack-cli]` が invalid として削除され、公開パッケージにCLIコマンドが含まれない問題が発生していた
- npm 11 の厳格なバリデーションにより、`.gitignore` で除外されている `dist/` 内のファイルを `bin` に指定すると invalid と判定される

# 概要

- `package.json` に `"files": ["dist"]` を追加し、公開対象ファイルを明示的に指定
- `bin` パスを `./dist/index.js` → `dist/index.js` に正規化（`npm pkg fix` による修正）

```mermaid
flowchart LR
    A[npm publish] --> B{filesフィールド?}
    B -->|なし 修正前| C[.gitignoreをフォールバック]
    C --> D[dist/が除外対象]
    D --> E[binエントリが invalid]
    E --> F[CLIコマンドなしで公開 ❌]
    B -->|あり 修正後| G[dist/を明示的に含む]
    G --> H[binエントリが有効]
    H --> I[正常に公開 ✅]
```

# 変更内容

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| `files` | 未設定 | `["dist"]` |
| `bin` パス | `./dist/index.js` | `dist/index.js` |
| パッケージサイズ | 97.1 kB（src, tests等含む） | 51.9 kB（distのみ） |