### PR TITLE
feat: history --format json に ts, thread_ts, reply_count を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/formatters/history-formatters.ts
+++ b/src/utils/formatters/history-formatters.ts
@@ -61,9 +61,12 @@ class JsonHistoryFormatter extends JsonFormatter<HistoryFormatterOptions> {
     return {
       channel: channelName,
       messages: messages.map((message) => ({
+        ts: message.ts,
         timestamp: formatTimestampFixed(message.ts),
         user: resolveUsername(message, users),
         text: message.text || '(no text)',
+        ...(message.thread_ts !== undefined && { thread_ts: message.thread_ts }),
+        ...(message.reply_count !== undefined && { reply_count: message.reply_count }),
       })),
       total: messages.length,
     };

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -61,6 +61,7 @@ export interface Message {
   bot_id?: string;
   ts: string;
   thread_ts?: string;
+  reply_count?: number;
   attachments?: unknown[];
   blocks?: unknown[];
 }

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -457,11 +457,13 @@ describe('history command', () => {
           channel: 'general',
           messages: [
             {
+              ts: '1609459300.000200',
               timestamp: '2021-01-01 00:01:40',
               user: 'jane.smith',
               text: 'Another message',
             },
             {
+              ts: '1609459200.000100',
               timestamp: '2021-01-01 00:00:00',
               user: 'john.doe',
               text: 'Hello world',
@@ -471,6 +473,74 @@ describe('history command', () => {
         };
 
         expect(mockConsole.logSpy).toHaveBeenCalledWith(JSON.stringify(expectedOutput, null, 2));
+      });
+
+      it('should include thread_ts and reply_count in JSON format when present', async () => {
+        vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+          token: 'test-token',
+          updatedAt: new Date().toISOString(),
+        });
+
+        const mockMessages = [
+          {
+            type: 'message',
+            text: 'Thread parent message',
+            user: 'U123456',
+            ts: '1609459200.000100',
+            thread_ts: '1609459200.000100',
+            reply_count: 3,
+          },
+          {
+            type: 'message',
+            text: 'Normal message',
+            user: 'U789012',
+            ts: '1609459100.000100',
+          },
+        ];
+
+        vi.mocked(mockSlackClient.getHistory).mockResolvedValue({
+          messages: mockMessages,
+          users: new Map([
+            ['U123456', 'john.doe'],
+            ['U789012', 'jane.smith'],
+          ]),
+        });
+
+        await program.parseAsync([
+          'node',
+          'slack-cli',
+          'history',
+          '-c',
+          'general',
+          '--format',
+          'json',
+        ]);
+
+        const logCall = mockConsole.logSpy.mock.calls.find((call: any[]) => {
+          try {
+            const parsed = JSON.parse(call[0]);
+            return parsed.channel === 'general';
+          } catch {
+            return false;
+          }
+        });
+        expect(logCall).toBeDefined();
+
+        const output = JSON.parse(logCall[0]);
+
+        // Message with thread should include thread_ts and reply_count
+        const threadMessage = output.messages.find(
+          (m: any) => m.text === 'Thread parent message'
+        );
+        expect(threadMessage.ts).toBe('1609459200.000100');
+        expect(threadMessage.thread_ts).toBe('1609459200.000100');
+        expect(threadMessage.reply_count).toBe(3);
+
+        // Normal message should not include thread_ts or reply_count
+        const normalMessage = output.messages.find((m: any) => m.text === 'Normal message');
+        expect(normalMessage.ts).toBe('1609459100.000100');
+        expect(normalMessage.thread_ts).toBeUndefined();
+        expect(normalMessage.reply_count).toBeUndefined();
       });
 
       it('should display messages in simple format when --format simple is specified', async () => {


### PR DESCRIPTION
JSON出力にraw TS（1609459200.000100形式）、thread_ts、reply_countを
含めることで、history → thread のコマンドチェーンを可能にする。
これにより jq 等でスレッド付き投稿を抽出し、そのスレッドを取得する
ワークフローが1コマンドで繋がるようになる。

バージョンを 0.3.0 → 0.4.0 に更新。

https://claude.ai/code/session_016vQoKJMF3d7bKqHec4zSmc