### PR TITLE
fix: replace any types with proper TypeScript types for improved type…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3] - 2026-02-22
+
+### Changed
+- Replace `any` types with proper TypeScript types in `MessageFormatterOptions` (`Channel`, `Message[]`)
+- Replace `any` type in `JsonMessageFormatter` output with explicit `MessageJsonOutput` interface
+- Replace `as any` cast in `MessageOperations.listScheduledMessages` with `ChatScheduledMessagesListArguments`
+- Replace `Promise<any>` return type in `ChannelOperations.fetchLatestMessage` with `Promise<Message | null>`
+- Replace `TOutput = any` default in `JsonFormatter` base class with `TOutput = unknown`
+
+### Added
+- New test file for message formatters (`tests/utils/formatters/message-formatters.test.ts`)
+
 ## [0.4.2] - 2026-02-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/formatters/base-formatter.ts
+++ b/src/utils/formatters/base-formatter.ts
@@ -6,7 +6,7 @@ export abstract class AbstractFormatter<T> implements BaseFormatter<T> {
   abstract format(data: T): void;
 }
 
-export abstract class JsonFormatter<TInput, TOutput = any> extends AbstractFormatter<TInput> {
+export abstract class JsonFormatter<TInput, TOutput = unknown> extends AbstractFormatter<TInput> {
   protected abstract transform(data: TInput): TOutput;
 
   format(data: TInput): void {

--- a/src/utils/formatters/message-formatters.ts
+++ b/src/utils/formatters/message-formatters.ts
@@ -3,10 +3,11 @@ import { AbstractFormatter, JsonFormatter, createFormatterFactory } from './base
 import { formatSlackTimestamp } from '../date-utils';
 import { formatMessageWithMentions } from '../format-utils';
 import { formatChannelName } from '../channel-formatter';
+import { Channel, Message } from '../slack-api-client';
 
 export interface MessageFormatterOptions {
-  channel: any;
-  messages: any[];
+  channel: Channel;
+  messages: Message[];
   users: Map<string, string>;
   countOnly: boolean;
   format: string;
@@ -51,12 +52,23 @@ class SimpleMessageFormatter extends AbstractFormatter<MessageFormatterOptions> 
   }
 }
 
-class JsonMessageFormatter extends JsonFormatter<MessageFormatterOptions> {
-  protected transform(options: MessageFormatterOptions) {
+interface MessageJsonOutput {
+  channel: string;
+  channelId: string;
+  unreadCount: number;
+  messages?: {
+    timestamp: string;
+    author: string;
+    text: string;
+  }[];
+}
+
+class JsonMessageFormatter extends JsonFormatter<MessageFormatterOptions, MessageJsonOutput> {
+  protected transform(options: MessageFormatterOptions): MessageJsonOutput {
     const { channel, messages, users, countOnly } = options;
     const channelName = formatChannelName(channel.name);
 
-    const output: any = {
+    const output: MessageJsonOutput = {
       channel: channelName,
       channelId: channel.id,
       unreadCount: channel.unread_count || 0,

--- a/src/utils/slack-operations/channel-operations.ts
+++ b/src/utils/slack-operations/channel-operations.ts
@@ -1,7 +1,7 @@
 import { BaseSlackClient } from './base-client';
 import { channelResolver } from '../channel-resolver';
 import { DEFAULTS } from '../constants';
-import { Channel, ListChannelsOptions } from '../slack-api-client';
+import { Channel, ListChannelsOptions, Message } from '../slack-api-client';
 import { WebClient } from '@slack/web-api';
 
 interface ChannelWithUnreadInfo extends Channel {
@@ -118,12 +118,14 @@ export class ChannelOperations extends BaseSlackClient {
     }
   }
 
-  private async fetchLatestMessage(channelId: string): Promise<any> {
+  private async fetchLatestMessage(channelId: string): Promise<Message | null> {
     const history = await this.client.conversations.history({
       channel: channelId,
       limit: 1,
     });
-    return history.messages && history.messages.length > 0 ? history.messages[0] : null;
+    return history.messages && history.messages.length > 0
+      ? (history.messages[0] as Message)
+      : null;
   }
 
   private async fetchUnreadMessageCount(channelId: string, lastRead: string): Promise<number> {

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -3,6 +3,7 @@ import {
   ChatPostMessageArguments,
   ChatScheduleMessageArguments,
   ChatScheduleMessageResponse,
+  ChatScheduledMessagesListArguments,
 } from '@slack/web-api';
 import { BaseSlackClient } from './base-client';
 import { channelResolver } from '../channel-resolver';
@@ -72,7 +73,7 @@ export class MessageOperations extends BaseSlackClient {
         )
       : undefined;
 
-    const params: { channel?: string; limit: number } = {
+    const params: ChatScheduledMessagesListArguments = {
       limit,
     };
 
@@ -80,7 +81,7 @@ export class MessageOperations extends BaseSlackClient {
       params.channel = channelId;
     }
 
-    const response = await this.client.chat.scheduledMessages.list(params as any);
+    const response = await this.client.chat.scheduledMessages.list(params);
     return (response.scheduled_messages || []) as ScheduledMessage[];
   }
 

--- a/tests/utils/formatters/message-formatters.test.ts
+++ b/tests/utils/formatters/message-formatters.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { createMessageFormatter, MessageFormatterOptions } from '../../../src/utils/formatters/message-formatters';
+import { Channel, Message } from '../../../src/utils/slack-api-client';
+
+describe('MessageFormatters', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  const createChannel = (overrides: Partial<Channel> = {}): Channel => ({
+    id: 'C123',
+    name: 'general',
+    is_private: false,
+    created: 1234567890,
+    unread_count: 3,
+    unread_count_display: 3,
+    ...overrides,
+  });
+
+  const createMessage = (overrides: Partial<Message> = {}): Message => ({
+    type: 'message',
+    ts: '1700000000.000000',
+    text: 'Hello world',
+    user: 'U123',
+    ...overrides,
+  });
+
+  const createOptions = (overrides: Partial<MessageFormatterOptions> = {}): MessageFormatterOptions => ({
+    channel: createChannel(),
+    messages: [createMessage()],
+    users: new Map([['U123', 'testuser']]),
+    countOnly: false,
+    format: 'table',
+    ...overrides,
+  });
+
+  describe('type safety', () => {
+    it('should accept Channel type for channel property', () => {
+      const channel: Channel = createChannel();
+      const options = createOptions({ channel });
+
+      // The formatter should work without type assertion
+      const formatter = createMessageFormatter('table');
+      expect(() => formatter.format(options)).not.toThrow();
+    });
+
+    it('should accept Message[] type for messages property', () => {
+      const messages: Message[] = [
+        createMessage({ text: 'First message', user: 'U123' }),
+        createMessage({ text: 'Second message', user: 'U456', ts: '1700000001.000000' }),
+      ];
+      const options = createOptions({
+        messages,
+        users: new Map([['U123', 'user1'], ['U456', 'user2']]),
+      });
+
+      const formatter = createMessageFormatter('table');
+      expect(() => formatter.format(options)).not.toThrow();
+    });
+  });
+
+  describe('table formatter', () => {
+    it('should display channel name and unread count', () => {
+      const options = createOptions();
+      const formatter = createMessageFormatter('table');
+      formatter.format(options);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('general');
+      expect(output).toContain('3 unread messages');
+    });
+
+    it('should display messages when countOnly is false', () => {
+      const options = createOptions();
+      const formatter = createMessageFormatter('table');
+      formatter.format(options);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('testuser');
+      expect(output).toContain('Hello world');
+    });
+
+    it('should not display messages when countOnly is true', () => {
+      const options = createOptions({ countOnly: true });
+      const formatter = createMessageFormatter('table');
+      formatter.format(options);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).not.toContain('Hello world');
+    });
+  });
+
+  describe('simple formatter', () => {
+    it('should display channel name with unread count in compact format', () => {
+      const options = createOptions();
+      const formatter = createMessageFormatter('simple');
+      formatter.format(options);
+
+      const output = consoleSpy.mock.calls.map((c) => c[0]).join('\n');
+      expect(output).toContain('general');
+      expect(output).toContain('(3)');
+    });
+  });
+
+  describe('json formatter', () => {
+    it('should output valid JSON with proper structure', () => {
+      const options = createOptions();
+      const formatter = createMessageFormatter('json');
+      formatter.format(options);
+
+      const jsonOutput = consoleSpy.mock.calls[0][0];
+      const parsed = JSON.parse(jsonOutput);
+
+      expect(parsed).toHaveProperty('channel');
+      expect(parsed).toHaveProperty('channelId', 'C123');
+      expect(parsed).toHaveProperty('unreadCount', 3);
+      expect(parsed).toHaveProperty('messages');
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]).toHaveProperty('author', 'testuser');
+      expect(parsed.messages[0]).toHaveProperty('text', 'Hello world');
+    });
+
+    it('should omit messages array when countOnly is true', () => {
+      const options = createOptions({ countOnly: true });
+      const formatter = createMessageFormatter('json');
+      formatter.format(options);
+
+      const jsonOutput = consoleSpy.mock.calls[0][0];
+      const parsed = JSON.parse(jsonOutput);
+
+      expect(parsed).toHaveProperty('channel');
+      expect(parsed).toHaveProperty('unreadCount', 3);
+      expect(parsed).not.toHaveProperty('messages');
+    });
+
+    it('should handle messages without user field', () => {
+      const options = createOptions({
+        messages: [createMessage({ user: undefined })],
+      });
+      const formatter = createMessageFormatter('json');
+      formatter.format(options);
+
+      const jsonOutput = consoleSpy.mock.calls[0][0];
+      const parsed = JSON.parse(jsonOutput);
+      expect(parsed.messages[0].author).toBe('unknown');
+    });
+  });
+
+  describe('default fallback', () => {
+    it('should fall back to table formatter for unknown format', () => {
+      const options = createOptions();
+      const formatter = createMessageFormatter('unknown');
+      expect(() => formatter.format(options)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
… safety

Replace all `any` usage in formatter and operations code with explicit types:
- MessageFormatterOptions: Channel/Message[] instead of any
- JsonMessageFormatter: typed MessageJsonOutput interface
- listScheduledMessages: ChatScheduledMessagesListArguments
- fetchLatestMessage: Message | null return type
- JsonFormatter base: TOutput = unknown default

https://claude.ai/code/session_01A2ipRp78MnrPaLZedJPieY