### PR TITLE
Refactor scheduled messages list parameters and remove unused import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -3,7 +3,6 @@ import {
   ChatPostMessageArguments,
   ChatScheduleMessageArguments,
   ChatScheduleMessageResponse,
-  ChatScheduledMessagesListArguments,
 } from '@slack/web-api';
 import { BaseSlackClient } from './base-client';
 import { channelResolver } from '../channel-resolver';
@@ -73,15 +72,10 @@ export class MessageOperations extends BaseSlackClient {
         )
       : undefined;
 
-    const params: ChatScheduledMessagesListArguments = {
+    const response = await this.client.chat.scheduledMessages.list({
       limit,
-    };
-
-    if (channelId) {
-      params.channel = channelId;
-    }
-
-    const response = await this.client.chat.scheduledMessages.list(params);
+      ...(channelId ? { channel: channelId } : {}),
+    });
     return (response.scheduled_messages || []) as ScheduledMessage[];
   }
 


### PR DESCRIPTION
## Summary
Simplified the parameter construction for the Slack API's `scheduledMessages.list()` call by removing unnecessary intermediate variable assignment and using inline object spread syntax.

## Key Changes
- Removed unused `ChatScheduledMessagesListArguments` import from `@slack/web-api`
- Refactored parameter object construction to use inline spread operator instead of conditional assignment
- Simplified the `listScheduledMessages` method by passing parameters directly to the API call
- Bumped version from 0.4.4 to 0.4.5

## Implementation Details
The change replaces the previous pattern of:
1. Creating a typed `params` object
2. Conditionally adding the `channel` property
3. Passing `params` to the API call

With a more concise approach that:
- Passes parameters directly to the API call
- Uses the spread operator `...(channelId ? { channel: channelId } : {})` for conditional property inclusion
- Removes the need for the explicit type annotation since the API call handles type inference

https://claude.ai/code/session_015hrFzXrM5g5KscBqtQojJw