### PR TITLE
Fix scheduled messages list API call parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.4.1",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.4.1",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "^7.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -74,6 +74,8 @@ export class MessageOperations extends BaseSlackClient {
 
     const response = await this.client.chat.scheduledMessages.list({
       limit,
+      latest: undefined,
+      oldest: undefined,
       ...(channelId ? { channel: channelId } : {}),
     });
     return (response.scheduled_messages || []) as ScheduledMessage[];

--- a/tests/utils/slack-operations/message-operations.test.ts
+++ b/tests/utils/slack-operations/message-operations.test.ts
@@ -64,7 +64,7 @@ describe('MessageOperations', () => {
 
       const result = await messageOps.listScheduledMessages(undefined, 20);
 
-      expect(mockClient.chat.scheduledMessages.list).toHaveBeenCalledWith({ limit: 20 });
+      expect(mockClient.chat.scheduledMessages.list).toHaveBeenCalledWith({ limit: 20, latest: undefined, oldest: undefined });
       expect(result).toHaveLength(1);
     });
   });


### PR DESCRIPTION
## Summary
This PR fixes the `listScheduledMessages` method in the MessageOperations class to explicitly pass `latest` and `oldest` parameters as `undefined` to the Slack API, ensuring consistent behavior and proper parameter handling.

## Key Changes
- Updated `MessageOperations.listScheduledMessages()` to explicitly include `latest: undefined` and `oldest: undefined` when calling the Slack API's `chat.scheduledMessages.list` endpoint
- Updated corresponding test expectations to match the new API call signature
- Bumped package version from 0.4.5 to 0.4.6

## Implementation Details
The change ensures that the Slack API client receives explicit `undefined` values for the `latest` and `oldest` parameters rather than omitting them entirely. This provides more predictable behavior and may help avoid edge cases where the API's default parameter handling could cause unexpected results when filtering scheduled messages by time range.

https://claude.ai/code/session_01HniKHLFZTUqb7PpN3bDu3e