### PR TITLE
feat: add reaction command for adding/removing emoji reactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.4.7",
+  "version": "0.5.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/reaction.ts
+++ b/src/commands/reaction.ts
@@ -1,0 +1,56 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import { ReactionOptions } from '../types/commands';
+import { parseProfile } from '../utils/option-parsers';
+import { createValidationHook, optionValidators } from '../utils/validators';
+
+export function setupReactionCommand(): Command {
+  const reactionCommand = new Command('reaction').description(
+    'Add or remove emoji reactions on messages'
+  );
+
+  const addCommand = new Command('add')
+    .description('Add a reaction to a message')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('-t, --timestamp <timestamp>', 'Message timestamp')
+    .requiredOption('-e, --emoji <emoji>', 'Emoji name (without colons)')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.reactionTimestamp]))
+    .action(
+      wrapCommand(async (options: ReactionOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.addReaction(options.channel, options.timestamp, options.emoji);
+        console.log(
+          chalk.green(`✓ Reaction :${options.emoji}: added to message in #${options.channel}`)
+        );
+      })
+    );
+
+  const removeCommand = new Command('remove')
+    .description('Remove a reaction from a message')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('-t, --timestamp <timestamp>', 'Message timestamp')
+    .requiredOption('-e, --emoji <emoji>', 'Emoji name (without colons)')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.reactionTimestamp]))
+    .action(
+      wrapCommand(async (options: ReactionOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.removeReaction(options.channel, options.timestamp, options.emoji);
+        console.log(
+          chalk.green(`✓ Reaction :${options.emoji}: removed from message in #${options.channel}`)
+        );
+      })
+    );
+
+  reactionCommand.addCommand(addCommand);
+  reactionCommand.addCommand(removeCommand);
+
+  return reactionCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { setupHistoryCommand } from './commands/history';
 import { setupUnreadCommand } from './commands/unread';
 import { setupScheduledCommand } from './commands/scheduled';
 import { setupSearchCommand } from './commands/search';
+import { setupReactionCommand } from './commands/reaction';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -25,5 +26,6 @@ program.addCommand(setupHistoryCommand());
 program.addCommand(setupUnreadCommand());
 program.addCommand(setupScheduledCommand());
 program.addCommand(setupSearchCommand());
+program.addCommand(setupReactionCommand());
 
 program.parse();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -58,6 +58,13 @@ export interface UnreadOptions {
   profile?: string;
 }
 
+export interface ReactionOptions {
+  channel: string;
+  timestamp: string;
+  emoji: string;
+  profile?: string;
+}
+
 export interface SearchOptions {
   query: string;
   sort?: 'score' | 'timestamp';

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -1,6 +1,7 @@
 import { ChatPostMessageResponse, ChatScheduleMessageResponse } from '@slack/web-api';
 import { ChannelOperations } from './slack-operations/channel-operations';
 import { MessageOperations } from './slack-operations/message-operations';
+import { ReactionOperations } from './slack-operations/reaction-operations';
 import {
   SearchOperations,
   SearchResult,
@@ -88,11 +89,13 @@ export interface ChannelUnreadResult {
 export class SlackApiClient {
   private channelOps: ChannelOperations;
   private messageOps: MessageOperations;
+  private reactionOps: ReactionOperations;
   private searchOps: SearchOperations;
 
   constructor(token: string) {
     this.channelOps = new ChannelOperations(token);
     this.messageOps = new MessageOperations(token);
+    this.reactionOps = new ReactionOperations(token);
     this.searchOps = new SearchOperations(token);
   }
 
@@ -139,6 +142,14 @@ export class SlackApiClient {
 
   async markAsRead(channelId: string): Promise<void> {
     return this.messageOps.markAsRead(channelId);
+  }
+
+  async addReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+    return this.reactionOps.addReaction(channel, timestamp, emoji);
+  }
+
+  async removeReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+    return this.reactionOps.removeReaction(channel, timestamp, emoji);
   }
 
   async searchMessages(query: string, options?: SearchMessagesOptions): Promise<SearchResult> {

--- a/src/utils/slack-operations/reaction-operations.ts
+++ b/src/utils/slack-operations/reaction-operations.ts
@@ -1,0 +1,45 @@
+import { BaseSlackClient } from './base-client';
+import { channelResolver } from '../channel-resolver';
+import { ChannelOperations } from './channel-operations';
+import { DEFAULTS } from '../constants';
+
+export class ReactionOperations extends BaseSlackClient {
+  private channelOps: ChannelOperations;
+
+  constructor(token: string) {
+    super(token);
+    this.channelOps = new ChannelOperations(token);
+  }
+
+  private stripColons(emoji: string): string {
+    return emoji.replace(/^:/, '').replace(/:$/, '');
+  }
+
+  private async resolveChannel(channel: string): Promise<string> {
+    return channelResolver.resolveChannelId(channel, () =>
+      this.channelOps.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+  }
+
+  async addReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+    const channelId = await this.resolveChannel(channel);
+    await this.client.reactions.add({
+      channel: channelId,
+      timestamp,
+      name: this.stripColons(emoji),
+    });
+  }
+
+  async removeReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
+    const channelId = await this.resolveChannel(channel);
+    await this.client.reactions.remove({
+      channel: channelId,
+      timestamp,
+      name: this.stripColons(emoji),
+    });
+  }
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -167,6 +167,16 @@ export const optionValidators = {
   },
 
   /**
+   * Validates reaction timestamp if provided
+   */
+  reactionTimestamp: (options: Record<string, unknown>): string | null => {
+    if (options.timestamp) {
+      return formatValidators.threadTimestamp(options.timestamp as string);
+    }
+    return null;
+  },
+
+  /**
    * Validates schedule options for send command
    */
   scheduleTiming: (options: Record<string, unknown>): string | null => {

--- a/tests/commands/reaction.test.ts
+++ b/tests/commands/reaction.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupReactionCommand } from '../../src/commands/reaction';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('reaction command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupReactionCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('add subcommand', () => {
+    it('should add a reaction to a message', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.addReaction).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'reaction',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '-e',
+        'thumbsup',
+      ]);
+
+      expect(mockSlackClient.addReaction).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456',
+        'thumbsup'
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Reaction :thumbsup: added')
+      );
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.addReaction).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'reaction',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '-e',
+        'thumbsup',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('remove subcommand', () => {
+    it('should remove a reaction from a message', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.removeReaction).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'reaction',
+        'remove',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '-e',
+        'thumbsup',
+      ]);
+
+      expect(mockSlackClient.removeReaction).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456',
+        'thumbsup'
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Reaction :thumbsup: removed')
+      );
+    });
+  });
+
+  describe('validation', () => {
+    it('should fail when timestamp format is invalid', async () => {
+      const reactionCommand = setupReactionCommand();
+      reactionCommand.exitOverride();
+
+      const addCommand = reactionCommand.commands.find((c: any) => c.name() === 'add')!;
+      addCommand.exitOverride();
+
+      await expect(
+        addCommand.parseAsync(['-c', 'general', '-t', 'invalid-ts', '-e', 'thumbsup'], {
+          from: 'user',
+        })
+      ).rejects.toThrow('Invalid thread timestamp format');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'reaction',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '-e',
+        'thumbsup',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle Slack API errors', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.addReaction).mockRejectedValue(new Error('already_reacted'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'reaction',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '-e',
+        'thumbsup',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/utils/slack-operations/reaction-operations.test.ts
+++ b/tests/utils/slack-operations/reaction-operations.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { ReactionOperations } from '../../../src/utils/slack-operations/reaction-operations';
+import { channelResolver } from '../../../src/utils/channel-resolver';
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    reactions: {
+      add: vi.fn(),
+      remove: vi.fn(),
+    },
+  })),
+  LogLevel: {
+    ERROR: 'error',
+  },
+}));
+
+vi.mock('../../../src/utils/channel-resolver');
+
+describe('ReactionOperations', () => {
+  let reactionOps: ReactionOperations;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    reactionOps = new ReactionOperations('test-token');
+    mockClient = (reactionOps as any).client;
+  });
+
+  describe('addReaction', () => {
+    it('should add a reaction to a message', async () => {
+      mockClient.reactions.add.mockResolvedValue({ ok: true });
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+
+      await reactionOps.addReaction('general', '1234567890.123456', 'thumbsup');
+
+      expect(channelResolver.resolveChannelId).toHaveBeenCalledWith(
+        'general',
+        expect.any(Function)
+      );
+      expect(mockClient.reactions.add).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        timestamp: '1234567890.123456',
+        name: 'thumbsup',
+      });
+    });
+
+    it('should handle channel ID directly', async () => {
+      mockClient.reactions.add.mockResolvedValue({ ok: true });
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+
+      await reactionOps.addReaction('C123456789', '1234567890.123456', 'eyes');
+
+      expect(mockClient.reactions.add).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        timestamp: '1234567890.123456',
+        name: 'eyes',
+      });
+    });
+
+    it('should strip colons from emoji name', async () => {
+      mockClient.reactions.add.mockResolvedValue({ ok: true });
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+
+      await reactionOps.addReaction('general', '1234567890.123456', ':thumbsup:');
+
+      expect(mockClient.reactions.add).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        timestamp: '1234567890.123456',
+        name: 'thumbsup',
+      });
+    });
+
+    it('should throw on API error', async () => {
+      mockClient.reactions.add.mockRejectedValue(new Error('already_reacted'));
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+
+      await expect(
+        reactionOps.addReaction('general', '1234567890.123456', 'thumbsup')
+      ).rejects.toThrow('already_reacted');
+    });
+  });
+
+  describe('removeReaction', () => {
+    it('should remove a reaction from a message', async () => {
+      mockClient.reactions.remove.mockResolvedValue({ ok: true });
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+
+      await reactionOps.removeReaction('general', '1234567890.123456', 'thumbsup');
+
+      expect(channelResolver.resolveChannelId).toHaveBeenCalledWith(
+        'general',
+        expect.any(Function)
+      );
+      expect(mockClient.reactions.remove).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        timestamp: '1234567890.123456',
+        name: 'thumbsup',
+      });
+    });
+
+    it('should strip colons from emoji name', async () => {
+      mockClient.reactions.remove.mockResolvedValue({ ok: true });
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+
+      await reactionOps.removeReaction('general', '1234567890.123456', ':eyes:');
+
+      expect(mockClient.reactions.remove).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        timestamp: '1234567890.123456',
+        name: 'eyes',
+      });
+    });
+
+    it('should throw on API error', async () => {
+      mockClient.reactions.remove.mockRejectedValue(new Error('no_reaction'));
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+
+      await expect(
+        reactionOps.removeReaction('general', '1234567890.123456', 'thumbsup')
+      ).rejects.toThrow('no_reaction');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #132

- Add `reaction add` subcommand to add emoji reactions to messages
- Add `reaction remove` subcommand to remove emoji reactions from messages
- Support channel name/ID resolution, colon stripping from emoji names, timestamp validation

## Changes

### New files
- `src/commands/reaction.ts` - CLI command with `add`/`remove` subcommands
- `src/utils/slack-operations/reaction-operations.ts` - Slack API operations for `reactions.add`/`reactions.remove`
- `tests/commands/reaction.test.ts` - Command-level tests
- `tests/utils/slack-operations/reaction-operations.test.ts` - Operations-level tests

### Modified files
- `src/index.ts` - Register the new reaction command
- `src/types/commands.ts` - Add `ReactionOptions` interface
- `src/utils/slack-api-client.ts` - Add `addReaction`/`removeReaction` methods
- `src/utils/validators.ts` - Add `reactionTimestamp` validator

## Usage

```bash
# Add a reaction
slack-cli reaction add -c general -t 1234567890.123456 -e thumbsup

# Remove a reaction
slack-cli reaction remove -c general -t 1234567890.123456 -e thumbsup
```

## Test plan

- [x] All 340 tests pass (13 new tests added)
- [x] Build passes
- [x] Lint passes
- [x] Format check passes
- [ ] CI passes