### PR TITLE
feat: add scheduled cancel subcommand for deleting scheduled messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/scheduled.ts
+++ b/src/commands/scheduled.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
+import chalk from 'chalk';
 import { wrapCommand } from '../utils/command-wrapper';
 import { createSlackClient } from '../utils/client-factory';
-import { ScheduledOptions } from '../types/commands';
-import { parseFormat, parseLimit } from '../utils/option-parsers';
+import { ScheduledListOptions, ScheduledCancelOptions } from '../types/commands';
+import { parseFormat, parseLimit, parseProfile } from '../utils/option-parsers';
 import { createValidationHook, optionValidators } from '../utils/validators';
 
 function formatPostAt(postAt: number): string {
@@ -33,7 +34,11 @@ function renderSimple(
 }
 
 export function setupScheduledCommand(): Command {
-  const scheduledCommand = new Command('scheduled')
+  const scheduledCommand = new Command('scheduled').description(
+    'Manage scheduled messages (list, cancel)'
+  );
+
+  const listCommand = new Command('list')
     .description('List scheduled messages')
     .option('-c, --channel <channel>', 'Filter by channel name or ID')
     .option('--limit <number>', 'Maximum number of scheduled messages to list', '50')
@@ -41,8 +46,9 @@ export function setupScheduledCommand(): Command {
     .option('--profile <profile>', 'Use specific workspace profile')
     .hook('preAction', createValidationHook([optionValidators.format]))
     .action(
-      wrapCommand(async (options: ScheduledOptions) => {
-        const client = await createSlackClient(options.profile);
+      wrapCommand(async (options: ScheduledListOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
         const limit = parseLimit(options.limit, 50);
         const messages = await client.listScheduledMessages(options.channel, limit);
 
@@ -66,6 +72,24 @@ export function setupScheduledCommand(): Command {
         renderTable(messages);
       })
     );
+
+  const cancelCommand = new Command('cancel')
+    .description('Cancel a scheduled message')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('--id <scheduledMessageId>', 'Scheduled message ID')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .action(
+      wrapCommand(async (options: ScheduledCancelOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.cancelScheduledMessage(options.channel, options.id);
+        console.log(chalk.green(`✓ Scheduled message ${options.id} cancelled`));
+      })
+    );
+
+  scheduledCommand.addCommand(listCommand);
+  scheduledCommand.addCommand(cancelCommand);
 
   return scheduledCommand;
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -25,10 +25,16 @@ export interface SendOptions {
   profile?: string;
 }
 
-export interface ScheduledOptions {
+export interface ScheduledListOptions {
   channel?: string;
   limit?: string;
   format?: 'table' | 'simple' | 'json';
+  profile?: string;
+}
+
+export interface ScheduledCancelOptions {
+  channel: string;
+  id: string;
   profile?: string;
 }
 

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -120,6 +120,10 @@ export class SlackApiClient {
     return this.messageOps.listScheduledMessages(channel, limit);
   }
 
+  async cancelScheduledMessage(channel: string, scheduledMessageId: string): Promise<void> {
+    return this.messageOps.cancelScheduledMessage(channel, scheduledMessageId);
+  }
+
   async listChannels(options: ListChannelsOptions): Promise<Channel[]> {
     return this.channelOps.listChannels(options);
   }

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -79,6 +79,21 @@ export class MessageOperations extends BaseSlackClient {
     return (response.scheduled_messages || []) as ScheduledMessage[];
   }
 
+  async cancelScheduledMessage(channel: string, scheduledMessageId: string): Promise<void> {
+    const channelId = await channelResolver.resolveChannelId(channel, () =>
+      this.channelOps.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    await this.client.chat.deleteScheduledMessage({
+      channel: channelId,
+      scheduled_message_id: scheduledMessageId,
+    });
+  }
+
   async getHistory(channel: string, options: HistoryOptions): Promise<HistoryResult> {
     // Resolve channel name to ID if needed
     const channelId = await channelResolver.resolveChannelId(channel, () =>

--- a/tests/commands/scheduled.test.ts
+++ b/tests/commands/scheduled.test.ts
@@ -51,81 +51,164 @@ describe('scheduled command', () => {
     restoreMocks();
   });
 
-  it('should list scheduled messages in table format by default', async () => {
-    vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
-      token: 'test-token',
-      updatedAt: new Date().toISOString(),
+  describe('list subcommand', () => {
+    it('should list scheduled messages in table format by default', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
+        mockScheduledMessages as any
+      );
+
+      await program.parseAsync(['node', 'slack-cli', 'scheduled', 'list']);
+
+      expect(mockSlackClient.listScheduledMessages).toHaveBeenCalledWith(undefined, 50);
+      expect(tableSpy).toHaveBeenCalled();
     });
-    vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
-      mockScheduledMessages as any
-    );
 
-    await program.parseAsync(['node', 'slack-cli', 'scheduled']);
+    it('should filter by channel and limit', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
+        mockScheduledMessages as any
+      );
 
-    expect(mockSlackClient.listScheduledMessages).toHaveBeenCalledWith(undefined, 50);
-    expect(tableSpy).toHaveBeenCalled();
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'scheduled',
+        'list',
+        '--channel',
+        'general',
+        '--limit',
+        '10',
+      ]);
+
+      expect(mockSlackClient.listScheduledMessages).toHaveBeenCalledWith('general', 10);
+    });
+
+    it('should output json format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
+        mockScheduledMessages as any
+      );
+
+      await program.parseAsync(['node', 'slack-cli', 'scheduled', 'list', '--format', 'json']);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('"id": "Q123"'));
+    });
+
+    it('should output simple format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
+        mockScheduledMessages as any
+      );
+
+      await program.parseAsync(['node', 'slack-cli', 'scheduled', 'list', '--format', 'simple']);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Q123'));
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Q456'));
+    });
+
+    it('should show empty message when no scheduled messages', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue([] as any);
+
+      await program.parseAsync(['node', 'slack-cli', 'scheduled', 'list']);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('No scheduled messages found');
+    });
   });
 
-  it('should filter by channel and limit', async () => {
-    vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
-      token: 'test-token',
-      updatedAt: new Date().toISOString(),
+  describe('cancel subcommand', () => {
+    it('should cancel a scheduled message', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.cancelScheduledMessage).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'scheduled',
+        'cancel',
+        '-c',
+        'general',
+        '--id',
+        'Q1298393284',
+      ]);
+
+      expect(mockSlackClient.cancelScheduledMessage).toHaveBeenCalledWith(
+        'general',
+        'Q1298393284'
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Scheduled message Q1298393284 cancelled')
+      );
     });
-    vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
-      mockScheduledMessages as any
-    );
 
-    await program.parseAsync([
-      'node',
-      'slack-cli',
-      'scheduled',
-      '--channel',
-      'general',
-      '--limit',
-      '10',
-    ]);
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.cancelScheduledMessage).mockResolvedValue();
 
-    expect(mockSlackClient.listScheduledMessages).toHaveBeenCalledWith('general', 10);
-  });
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'scheduled',
+        'cancel',
+        '-c',
+        'general',
+        '--id',
+        'Q123',
+        '--profile',
+        'work',
+      ]);
 
-  it('should output json format', async () => {
-    vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
-      token: 'test-token',
-      updatedAt: new Date().toISOString(),
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
     });
-    vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
-      mockScheduledMessages as any
-    );
 
-    await program.parseAsync(['node', 'slack-cli', 'scheduled', '--format', 'json']);
+    it('should handle API errors', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.cancelScheduledMessage).mockRejectedValue(
+        new Error('invalid_scheduled_message_id')
+      );
 
-    expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('"id": "Q123"'));
-  });
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'scheduled',
+        'cancel',
+        '-c',
+        'general',
+        '--id',
+        'Q_INVALID',
+      ]);
 
-  it('should output simple format', async () => {
-    vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
-      token: 'test-token',
-      updatedAt: new Date().toISOString(),
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
     });
-    vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue(
-      mockScheduledMessages as any
-    );
-
-    await program.parseAsync(['node', 'slack-cli', 'scheduled', '--format', 'simple']);
-
-    expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Q123'));
-    expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Q456'));
-  });
-
-  it('should show empty message when no scheduled messages', async () => {
-    vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
-      token: 'test-token',
-      updatedAt: new Date().toISOString(),
-    });
-    vi.mocked(mockSlackClient.listScheduledMessages).mockResolvedValue([] as any);
-
-    await program.parseAsync(['node', 'slack-cli', 'scheduled']);
-
-    expect(mockConsole.logSpy).toHaveBeenCalledWith('No scheduled messages found');
   });
 });


### PR DESCRIPTION
## Summary

Closes #110

Refactor the `scheduled` command into a subcommand structure and add cancel functionality:
- `scheduled list` - List scheduled messages (existing functionality)
- `scheduled cancel` - Cancel a scheduled message using `chat.deleteScheduledMessage` API

### Breaking change
`slack-cli scheduled` now requires a subcommand (`list` or `cancel`). Previously it listed directly.

## Changes

- `src/commands/scheduled.ts` - Refactored to subcommand structure (`list`/`cancel`)
- `src/utils/slack-operations/message-operations.ts` - Added `cancelScheduledMessage` method
- `src/utils/slack-api-client.ts` - Added `cancelScheduledMessage` delegation
- `src/types/commands.ts` - Added `ScheduledListOptions`/`ScheduledCancelOptions`, replaced `ScheduledOptions`
- `tests/commands/scheduled.test.ts` - Updated tests for subcommand structure, added cancel tests

## Usage

```bash
# List scheduled messages
slack-cli scheduled list
slack-cli scheduled list -c general --format json

# Cancel a scheduled message
slack-cli scheduled cancel -c general --id Q1298393284
```

## Test plan

- [x] All 343 tests pass (3 new tests added)
- [x] Build passes
- [x] Lint passes
- [x] Format check passes
- [ ] CI passes