### PR TITLE
feat: add edit command for updating sent messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/edit.ts
+++ b/src/commands/edit.ts
@@ -1,0 +1,28 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import { EditOptions } from '../types/commands';
+import { parseProfile } from '../utils/option-parsers';
+import { createValidationHook, optionValidators } from '../utils/validators';
+
+export function setupEditCommand(): Command {
+  const editCommand = new Command('edit')
+    .description('Edit a sent message')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('--ts <timestamp>', 'Message timestamp to edit')
+    .requiredOption('-m, --message <message>', 'New message text')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.editTimestamp]))
+    .action(
+      wrapCommand(async (options: EditOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.updateMessage(options.channel, options.ts, options.message);
+        console.log(chalk.green(`✓ Message updated successfully in #${options.channel}`));
+      })
+    );
+
+  return editCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { setupHistoryCommand } from './commands/history';
 import { setupUnreadCommand } from './commands/unread';
 import { setupScheduledCommand } from './commands/scheduled';
 import { setupSearchCommand } from './commands/search';
+import { setupEditCommand } from './commands/edit';
 import { setupReactionCommand } from './commands/reaction';
 import { readFileSync } from 'fs';
 import { join } from 'path';
@@ -26,6 +27,7 @@ program.addCommand(setupHistoryCommand());
 program.addCommand(setupUnreadCommand());
 program.addCommand(setupScheduledCommand());
 program.addCommand(setupSearchCommand());
+program.addCommand(setupEditCommand());
 program.addCommand(setupReactionCommand());
 
 program.parse();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -64,6 +64,13 @@ export interface UnreadOptions {
   profile?: string;
 }
 
+export interface EditOptions {
+  channel: string;
+  ts: string;
+  message: string;
+  profile?: string;
+}
+
 export interface ReactionOptions {
   channel: string;
   timestamp: string;

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -1,4 +1,8 @@
-import { ChatPostMessageResponse, ChatScheduleMessageResponse } from '@slack/web-api';
+import {
+  ChatPostMessageResponse,
+  ChatScheduleMessageResponse,
+  ChatUpdateResponse,
+} from '@slack/web-api';
 import { ChannelOperations } from './slack-operations/channel-operations';
 import { MessageOperations } from './slack-operations/message-operations';
 import { ReactionOperations } from './slack-operations/reaction-operations';
@@ -114,6 +118,10 @@ export class SlackApiClient {
     thread_ts?: string
   ): Promise<ChatScheduleMessageResponse> {
     return this.messageOps.scheduleMessage(channel, text, post_at, thread_ts);
+  }
+
+  async updateMessage(channel: string, ts: string, text: string): Promise<ChatUpdateResponse> {
+    return this.messageOps.updateMessage(channel, ts, text);
   }
 
   async listScheduledMessages(channel?: string, limit = 50): Promise<ScheduledMessage[]> {

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -3,6 +3,7 @@ import {
   ChatPostMessageArguments,
   ChatScheduleMessageArguments,
   ChatScheduleMessageResponse,
+  ChatUpdateResponse,
 } from '@slack/web-api';
 import { BaseSlackClient } from './base-client';
 import { channelResolver } from '../channel-resolver';
@@ -77,6 +78,22 @@ export class MessageOperations extends BaseSlackClient {
       ...(channelId ? { channel: channelId } : {}),
     });
     return (response.scheduled_messages || []) as ScheduledMessage[];
+  }
+
+  async updateMessage(channel: string, ts: string, text: string): Promise<ChatUpdateResponse> {
+    const channelId = await channelResolver.resolveChannelId(channel, () =>
+      this.channelOps.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    return await this.client.chat.update({
+      channel: channelId,
+      ts,
+      text,
+    });
   }
 
   async cancelScheduledMessage(channel: string, scheduledMessageId: string): Promise<void> {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -167,6 +167,19 @@ export const optionValidators = {
   },
 
   /**
+   * Validates edit message timestamp if provided
+   */
+  editTimestamp: (options: Record<string, unknown>): string | null => {
+    if (options.ts) {
+      const pattern = /^\d{10}\.\d{6}$/;
+      if (!pattern.test(options.ts as string)) {
+        return 'Invalid message timestamp format';
+      }
+    }
+    return null;
+  },
+
+  /**
    * Validates reaction timestamp if provided
    */
   reactionTimestamp: (options: Record<string, unknown>): string | null => {

--- a/tests/commands/edit.test.ts
+++ b/tests/commands/edit.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupEditCommand } from '../../src/commands/edit';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('edit command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupEditCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('edit message', () => {
+    it('should update a message', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.updateMessage).mockResolvedValue({
+        ok: true,
+        ts: '1234567890.123456',
+        channel: 'C1234567890',
+        text: 'Updated message',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'edit',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+        '-m',
+        'Updated message',
+      ]);
+
+      expect(mockSlackClient.updateMessage).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456',
+        'Updated message'
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Message updated successfully in #general')
+      );
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.updateMessage).mockResolvedValue({
+        ok: true,
+        ts: '1234567890.123456',
+        channel: 'C1234567890',
+        text: 'Updated',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'edit',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+        '-m',
+        'Updated',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('validation', () => {
+    it('should fail when timestamp format is invalid', async () => {
+      const editCommand = setupEditCommand();
+      editCommand.exitOverride();
+
+      await expect(
+        editCommand.parseAsync(['-c', 'general', '--ts', 'invalid-ts', '-m', 'Hello'], {
+          from: 'user',
+        })
+      ).rejects.toThrow('Invalid message timestamp format');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'edit',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+        '-m',
+        'Hello',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle message_not_found error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.updateMessage).mockRejectedValue(new Error('message_not_found'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'edit',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+        '-m',
+        'Hello',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle cant_update_message error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.updateMessage).mockRejectedValue(
+        new Error('cant_update_message')
+      );
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'edit',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+        '-m',
+        'Hello',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #102

Add `edit` command to update already-sent messages using the `chat.update` Slack API.

## Changes

### New files
- `src/commands/edit.ts` - CLI command for editing messages
- `tests/commands/edit.test.ts` - Command-level tests (6 tests)

### Modified files
- `src/index.ts` - Register the new edit command
- `src/types/commands.ts` - Add `EditOptions` interface
- `src/utils/slack-api-client.ts` - Add `updateMessage` method
- `src/utils/slack-operations/message-operations.ts` - Add `updateMessage` using `chat.update`
- `src/utils/validators.ts` - Add `editTimestamp` validator

## Usage

```bash
slack-cli edit -c general --ts 1234567890.123456 -m "Updated message text"
slack-cli edit -c general --ts 1234567890.123456 -m "Fixed typo" --profile work
```

## Test plan

- [x] All 349 tests pass (6 new tests added)
- [x] Build passes
- [x] Lint passes
- [x] Format check passes
- [ ] CI passes