### PR TITLE
feat: add delete command for removing sent messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ slack-cli edit -c general --ts 1234567890.123456 -m "Updated message text"
 slack-cli edit -c general --ts 1234567890.123456 -m "Fixed typo" --profile work
 ```
 
+### Delete Messages
+
+```bash
+# Delete a message
+slack-cli delete -c general --ts 1234567890.123456
+
+# Use specific profile
+slack-cli delete -c general --ts 1234567890.123456 --profile work
+```
+
 ### Upload Files
 
 ```bash
@@ -317,6 +327,13 @@ slack-cli config set --token NEW_TOKEN
 | --channel | -c    | Target channel name or ID (required)           |
 | --ts      |       | Message timestamp to edit (required)           |
 | --message | -m    | New message text (required)                    |
+
+### delete command
+
+| Option    | Short | Description                                    |
+| --------- | ----- | ---------------------------------------------- |
+| --channel | -c    | Target channel name or ID (required)           |
+| --ts      |       | Message timestamp to delete (required)         |
 
 ### upload command
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/delete.ts
+++ b/src/commands/delete.ts
@@ -1,0 +1,27 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import { DeleteOptions } from '../types/commands';
+import { parseProfile } from '../utils/option-parsers';
+import { createValidationHook, optionValidators } from '../utils/validators';
+
+export function setupDeleteCommand(): Command {
+  const deleteCommand = new Command('delete')
+    .description('Delete a sent message')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('--ts <timestamp>', 'Message timestamp to delete')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.deleteTimestamp]))
+    .action(
+      wrapCommand(async (options: DeleteOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.deleteMessage(options.channel, options.ts);
+        console.log(chalk.green(`✓ Message deleted successfully from #${options.channel}`));
+      })
+    );
+
+  return deleteCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { setupUnreadCommand } from './commands/unread';
 import { setupScheduledCommand } from './commands/scheduled';
 import { setupSearchCommand } from './commands/search';
 import { setupEditCommand } from './commands/edit';
+import { setupDeleteCommand } from './commands/delete';
 import { setupUploadCommand } from './commands/upload';
 import { setupReactionCommand } from './commands/reaction';
 import { readFileSync } from 'fs';
@@ -29,6 +30,7 @@ program.addCommand(setupUnreadCommand());
 program.addCommand(setupScheduledCommand());
 program.addCommand(setupSearchCommand());
 program.addCommand(setupEditCommand());
+program.addCommand(setupDeleteCommand());
 program.addCommand(setupUploadCommand());
 program.addCommand(setupReactionCommand());
 

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -83,6 +83,12 @@ export interface EditOptions {
   profile?: string;
 }
 
+export interface DeleteOptions {
+  channel: string;
+  ts: string;
+  profile?: string;
+}
+
 export interface ReactionOptions {
   channel: string;
   timestamp: string;

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -127,6 +127,10 @@ export class SlackApiClient {
     return this.messageOps.updateMessage(channel, ts, text);
   }
 
+  async deleteMessage(channel: string, ts: string): Promise<void> {
+    return this.messageOps.deleteMessage(channel, ts);
+  }
+
   async listScheduledMessages(channel?: string, limit = 50): Promise<ScheduledMessage[]> {
     return this.messageOps.listScheduledMessages(channel, limit);
   }

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -96,6 +96,21 @@ export class MessageOperations extends BaseSlackClient {
     });
   }
 
+  async deleteMessage(channel: string, ts: string): Promise<void> {
+    const channelId = await channelResolver.resolveChannelId(channel, () =>
+      this.channelOps.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    await this.client.chat.delete({
+      channel: channelId,
+      ts,
+    });
+  }
+
   async cancelScheduledMessage(channel: string, scheduledMessageId: string): Promise<void> {
     const channelId = await channelResolver.resolveChannelId(channel, () =>
       this.channelOps.listChannels({

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -203,6 +203,19 @@ export const optionValidators = {
   },
 
   /**
+   * Validates delete message timestamp if provided
+   */
+  deleteTimestamp: (options: Record<string, unknown>): string | null => {
+    if (options.ts) {
+      const pattern = /^\d{10}\.\d{6}$/;
+      if (!pattern.test(options.ts as string)) {
+        return 'Invalid message timestamp format';
+      }
+    }
+    return null;
+  },
+
+  /**
    * Validates reaction timestamp if provided
    */
   reactionTimestamp: (options: Record<string, unknown>): string | null => {

--- a/tests/commands/delete.test.ts
+++ b/tests/commands/delete.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupDeleteCommand } from '../../src/commands/delete';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('delete command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupDeleteCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('delete message', () => {
+    it('should delete a message', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.deleteMessage).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'delete',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+      ]);
+
+      expect(mockSlackClient.deleteMessage).toHaveBeenCalledWith('general', '1234567890.123456');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Message deleted successfully from #general')
+      );
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.deleteMessage).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'delete',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('validation', () => {
+    it('should fail when timestamp format is invalid', async () => {
+      const deleteCommand = setupDeleteCommand();
+      deleteCommand.exitOverride();
+
+      await expect(
+        deleteCommand.parseAsync(['-c', 'general', '--ts', 'invalid-ts'], { from: 'user' })
+      ).rejects.toThrow('Invalid message timestamp format');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'delete',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle message_not_found error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.deleteMessage).mockRejectedValue(new Error('message_not_found'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'delete',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle cant_delete_message error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.deleteMessage).mockRejectedValue(
+        new Error('cant_delete_message')
+      );
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'delete',
+        '-c',
+        'general',
+        '--ts',
+        '1234567890.123456',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #103

Add `delete` command to remove sent messages using the `chat.delete` Slack API. Completes the message CRUD operations (send, edit, delete).

## Changes

### New files
- `src/commands/delete.ts` - CLI command for deleting messages
- `tests/commands/delete.test.ts` - Command-level tests (6 tests)

### Modified files
- `src/index.ts` - Register the new delete command
- `src/types/commands.ts` - Add `DeleteOptions` interface
- `src/utils/slack-api-client.ts` - Add `deleteMessage` method
- `src/utils/slack-operations/message-operations.ts` - Add `deleteMessage` using `chat.delete`
- `src/utils/validators.ts` - Add `deleteTimestamp` validator
- `README.md` - Add delete command documentation

## Usage

```bash
slack-cli delete -c general --ts 1234567890.123456
slack-cli delete -c general --ts 1234567890.123456 --profile work
```

## Test plan

- [x] All 370 tests pass (6 new tests added)
- [x] Build passes
- [x] Lint passes
- [x] Format check passes
- [ ] CI passes