### PR TITLE
feat: add pin command for pinning/unpinning messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,23 @@ slack-cli reaction add -c general -t 1234567890.123456 -e thumbsup
 slack-cli reaction remove -c general -t 1234567890.123456 -e thumbsup
 ```
 
+### Pins
+
+```bash
+# Pin a message
+slack-cli pin add -c general -t 1234567890.123456
+
+# Unpin a message
+slack-cli pin remove -c general -t 1234567890.123456
+
+# List pinned items in a channel
+slack-cli pin list -c general
+
+# Output in different formats
+slack-cli pin list -c general --format json
+slack-cli pin list -c general --format simple
+```
+
 ### Scheduled Messages
 
 ```bash
@@ -358,6 +375,24 @@ slack-cli config set --token NEW_TOKEN
 
 Subcommands: `add`, `remove`
 
+### pin command
+
+Subcommands: `add`, `remove`, `list`
+
+#### pin add / pin remove
+
+| Option      | Short | Description                          |
+| ----------- | ----- | ------------------------------------ |
+| --channel   | -c    | Channel name or ID (required)        |
+| --timestamp | -t    | Message timestamp (required)         |
+
+#### pin list
+
+| Option    | Short | Description                                         |
+| --------- | ----- | --------------------------------------------------- |
+| --channel | -c    | Channel name or ID (required)                       |
+| --format  |       | Output format: table, simple, json (default: table) |
+
 ### scheduled command
 
 Subcommands: `list`, `cancel`
@@ -390,6 +425,8 @@ Your Slack API token needs the following scopes:
 - `users:read` - Access user information for unread counts
 - `search:read` - Search messages (user token only, not supported with bot tokens)
 - `reactions:write` - Add and remove reactions
+- `pins:read` - List pinned items in a channel
+- `pins:write` - Pin and unpin messages
 - `files:write` - Upload files and snippets
 
 ## Advanced Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/pin.ts
+++ b/src/commands/pin.ts
@@ -1,0 +1,110 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import { PinOptions, PinListOptions } from '../types/commands';
+import { parseFormat, parseProfile } from '../utils/option-parsers';
+import { createValidationHook, optionValidators } from '../utils/validators';
+import { PinnedItem } from '../utils/slack-api-client';
+
+function formatCreated(created: number): string {
+  return new Date(created * 1000).toISOString();
+}
+
+function renderTable(items: PinnedItem[]) {
+  const rows = items.map((item) => ({
+    type: item.type || 'unknown',
+    created: item.created ? formatCreated(item.created) : '',
+    created_by: item.created_by || '',
+    ts: item.message?.ts || '',
+    text: item.message?.text || '',
+  }));
+
+  console.table(rows);
+}
+
+function renderSimple(items: PinnedItem[]) {
+  for (const item of items) {
+    const created = item.created ? formatCreated(item.created) : '';
+    const text = item.message?.text || '';
+    const ts = item.message?.ts || '';
+    console.log(`${created} ${ts} ${text}`);
+  }
+}
+
+export function setupPinCommand(): Command {
+  const pinCommand = new Command('pin').description(
+    'Add, remove, or list pinned messages in a channel'
+  );
+
+  const addCommand = new Command('add')
+    .description('Pin a message in a channel')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('-t, --timestamp <timestamp>', 'Message timestamp')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.pinTimestamp]))
+    .action(
+      wrapCommand(async (options: PinOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.addPin(options.channel, options.timestamp);
+        console.log(chalk.green(`✓ Pin added to message in #${options.channel}`));
+      })
+    );
+
+  const removeCommand = new Command('remove')
+    .description('Unpin a message in a channel')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('-t, --timestamp <timestamp>', 'Message timestamp')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.pinTimestamp]))
+    .action(
+      wrapCommand(async (options: PinOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.removePin(options.channel, options.timestamp);
+        console.log(chalk.green(`✓ Pin removed from message in #${options.channel}`));
+      })
+    );
+
+  const listCommand = new Command('list')
+    .description('List pinned items in a channel')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .option('--format <format>', 'Output format: table, simple, json', 'table')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.format]))
+    .action(
+      wrapCommand(async (options: PinListOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+        const items = await client.listPins(options.channel);
+
+        if (items.length === 0) {
+          console.log('No pinned items found');
+          return;
+        }
+
+        const format = parseFormat(options.format);
+
+        if (format === 'json') {
+          console.log(JSON.stringify(items, null, 2));
+          return;
+        }
+
+        if (format === 'simple') {
+          renderSimple(items);
+          return;
+        }
+
+        renderTable(items);
+      })
+    );
+
+  pinCommand.addCommand(addCommand);
+  pinCommand.addCommand(removeCommand);
+  pinCommand.addCommand(listCommand);
+
+  return pinCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { setupEditCommand } from './commands/edit';
 import { setupDeleteCommand } from './commands/delete';
 import { setupUploadCommand } from './commands/upload';
 import { setupReactionCommand } from './commands/reaction';
+import { setupPinCommand } from './commands/pin';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -33,5 +34,6 @@ program.addCommand(setupEditCommand());
 program.addCommand(setupDeleteCommand());
 program.addCommand(setupUploadCommand());
 program.addCommand(setupReactionCommand());
+program.addCommand(setupPinCommand());
 
 program.parse();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -96,6 +96,18 @@ export interface ReactionOptions {
   profile?: string;
 }
 
+export interface PinOptions {
+  channel: string;
+  timestamp: string;
+  profile?: string;
+}
+
+export interface PinListOptions {
+  channel: string;
+  format?: 'table' | 'simple' | 'json';
+  profile?: string;
+}
+
 export interface SearchOptions {
   query: string;
   sort?: 'score' | 'timestamp';

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -7,6 +7,7 @@ import { ChannelOperations } from './slack-operations/channel-operations';
 import { MessageOperations } from './slack-operations/message-operations';
 import { FileOperations, UploadFileOptions } from './slack-operations/file-operations';
 import { ReactionOperations } from './slack-operations/reaction-operations';
+import { PinOperations, PinnedItem } from './slack-operations/pin-operations';
 import {
   SearchOperations,
   SearchResult,
@@ -14,7 +15,7 @@ import {
   SearchMatch,
 } from './slack-operations/search-operations';
 
-export type { SearchResult, SearchMessagesOptions, SearchMatch };
+export type { SearchResult, SearchMessagesOptions, SearchMatch, PinnedItem };
 
 export interface Channel {
   id: string;
@@ -96,6 +97,7 @@ export class SlackApiClient {
   private messageOps: MessageOperations;
   private fileOps: FileOperations;
   private reactionOps: ReactionOperations;
+  private pinOps: PinOperations;
   private searchOps: SearchOperations;
 
   constructor(token: string) {
@@ -103,6 +105,7 @@ export class SlackApiClient {
     this.messageOps = new MessageOperations(token);
     this.fileOps = new FileOperations(token);
     this.reactionOps = new ReactionOperations(token);
+    this.pinOps = new PinOperations(token);
     this.searchOps = new SearchOperations(token);
   }
 
@@ -173,6 +176,18 @@ export class SlackApiClient {
 
   async removeReaction(channel: string, timestamp: string, emoji: string): Promise<void> {
     return this.reactionOps.removeReaction(channel, timestamp, emoji);
+  }
+
+  async addPin(channel: string, timestamp: string): Promise<void> {
+    return this.pinOps.addPin(channel, timestamp);
+  }
+
+  async removePin(channel: string, timestamp: string): Promise<void> {
+    return this.pinOps.removePin(channel, timestamp);
+  }
+
+  async listPins(channel: string): Promise<PinnedItem[]> {
+    return this.pinOps.listPins(channel);
   }
 
   async searchMessages(query: string, options?: SearchMessagesOptions): Promise<SearchResult> {

--- a/src/utils/slack-operations/pin-operations.ts
+++ b/src/utils/slack-operations/pin-operations.ts
@@ -1,0 +1,58 @@
+import { BaseSlackClient } from './base-client';
+import { channelResolver } from '../channel-resolver';
+import { ChannelOperations } from './channel-operations';
+import { DEFAULTS } from '../constants';
+
+export interface PinnedItem {
+  type?: string;
+  created?: number;
+  created_by?: string;
+  message?: {
+    text?: string;
+    user?: string;
+    ts?: string;
+  };
+}
+
+export class PinOperations extends BaseSlackClient {
+  private channelOps: ChannelOperations;
+
+  constructor(token: string) {
+    super(token);
+    this.channelOps = new ChannelOperations(token);
+  }
+
+  private async resolveChannel(channel: string): Promise<string> {
+    return channelResolver.resolveChannelId(channel, () =>
+      this.channelOps.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+  }
+
+  async addPin(channel: string, timestamp: string): Promise<void> {
+    const channelId = await this.resolveChannel(channel);
+    await this.client.pins.add({
+      channel: channelId,
+      timestamp,
+    });
+  }
+
+  async removePin(channel: string, timestamp: string): Promise<void> {
+    const channelId = await this.resolveChannel(channel);
+    await this.client.pins.remove({
+      channel: channelId,
+      timestamp,
+    });
+  }
+
+  async listPins(channel: string): Promise<PinnedItem[]> {
+    const channelId = await this.resolveChannel(channel);
+    const response = await this.client.pins.list({
+      channel: channelId,
+    });
+    return (response.items || []) as PinnedItem[];
+  }
+}

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -226,6 +226,16 @@ export const optionValidators = {
   },
 
   /**
+   * Validates pin timestamp if provided
+   */
+  pinTimestamp: (options: Record<string, unknown>): string | null => {
+    if (options.timestamp) {
+      return formatValidators.threadTimestamp(options.timestamp as string);
+    }
+    return null;
+  },
+
+  /**
    * Validates schedule options for send command
    */
   scheduleTiming: (options: Record<string, unknown>): string | null => {

--- a/tests/commands/pin.test.ts
+++ b/tests/commands/pin.test.ts
@@ -1,0 +1,339 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupPinCommand } from '../../src/commands/pin';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('pin command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupPinCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('add subcommand', () => {
+    it('should add a pin to a message', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.addPin).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+      ]);
+
+      expect(mockSlackClient.addPin).toHaveBeenCalledWith('general', '1234567890.123456');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Pin added to message in #general')
+      );
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.addPin).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('remove subcommand', () => {
+    it('should remove a pin from a message', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.removePin).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'remove',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+      ]);
+
+      expect(mockSlackClient.removePin).toHaveBeenCalledWith('general', '1234567890.123456');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Pin removed from message in #general')
+      );
+    });
+  });
+
+  describe('list subcommand', () => {
+    it('should list pinned items in table format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listPins).mockResolvedValue([
+        {
+          type: 'message',
+          created: 1700000000,
+          created_by: 'U123',
+          message: {
+            text: 'Pinned message 1',
+            user: 'U123',
+            ts: '1234567890.123456',
+          },
+        },
+      ]);
+
+      await program.parseAsync(['node', 'slack-cli', 'pin', 'list', '-c', 'general']);
+
+      expect(mockSlackClient.listPins).toHaveBeenCalledWith('general');
+      expect(mockConsole.logSpy).toHaveBeenCalled();
+    });
+
+    it('should output in json format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      const pins = [
+        {
+          type: 'message',
+          created: 1700000000,
+          created_by: 'U123',
+          message: {
+            text: 'Pinned message',
+            user: 'U123',
+            ts: '1234567890.123456',
+          },
+        },
+      ];
+      vi.mocked(mockSlackClient.listPins).mockResolvedValue(pins);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'list',
+        '-c',
+        'general',
+        '--format',
+        'json',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(JSON.stringify(pins, null, 2));
+    });
+
+    it('should output in simple format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listPins).mockResolvedValue([
+        {
+          type: 'message',
+          created: 1700000000,
+          created_by: 'U123',
+          message: {
+            text: 'Pinned message',
+            user: 'U123',
+            ts: '1234567890.123456',
+          },
+        },
+      ]);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'list',
+        '-c',
+        'general',
+        '--format',
+        'simple',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Pinned message')
+      );
+    });
+
+    it('should show message when no pins found', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listPins).mockResolvedValue([]);
+
+      await program.parseAsync(['node', 'slack-cli', 'pin', 'list', '-c', 'general']);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('No pinned items found');
+    });
+
+    it('should use specified profile for list', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listPins).mockResolvedValue([]);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'list',
+        '-c',
+        'general',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('validation', () => {
+    it('should fail when timestamp format is invalid for add', async () => {
+      const pinCommand = setupPinCommand();
+      pinCommand.exitOverride();
+
+      const addCommand = pinCommand.commands.find((c: any) => c.name() === 'add')!;
+      addCommand.exitOverride();
+
+      await expect(
+        addCommand.parseAsync(['-c', 'general', '-t', 'invalid-ts'], {
+          from: 'user',
+        })
+      ).rejects.toThrow('Invalid thread timestamp format');
+    });
+
+    it('should fail when timestamp format is invalid for remove', async () => {
+      const pinCommand = setupPinCommand();
+      pinCommand.exitOverride();
+
+      const removeCommand = pinCommand.commands.find((c: any) => c.name() === 'remove')!;
+      removeCommand.exitOverride();
+
+      await expect(
+        removeCommand.parseAsync(['-c', 'general', '-t', 'invalid-ts'], {
+          from: 'user',
+        })
+      ).rejects.toThrow('Invalid thread timestamp format');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle already_pinned error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.addPin).mockRejectedValue(new Error('already_pinned'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'add',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle no_pin error on remove', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.removePin).mockRejectedValue(new Error('no_pin'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'pin',
+        'remove',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/utils/slack-operations/pin-operations.test.ts
+++ b/tests/utils/slack-operations/pin-operations.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PinOperations } from '../../../src/utils/slack-operations/pin-operations';
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    pins: {
+      add: vi.fn(),
+      remove: vi.fn(),
+      list: vi.fn(),
+    },
+  })),
+  LogLevel: {
+    ERROR: 'error',
+  },
+}));
+
+vi.mock('../../../src/utils/channel-resolver');
+
+import { channelResolver } from '../../../src/utils/channel-resolver';
+
+describe('PinOperations', () => {
+  let pinOps: PinOperations;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pinOps = new PinOperations('test-token');
+    mockClient = (pinOps as any).client;
+  });
+
+  describe('addPin', () => {
+    it('should add a pin to a message', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.add.mockResolvedValue({ ok: true });
+
+      await pinOps.addPin('general', '1234567890.123456');
+
+      expect(channelResolver.resolveChannelId).toHaveBeenCalledWith(
+        'general',
+        expect.any(Function)
+      );
+      expect(mockClient.pins.add).toHaveBeenCalledWith({
+        channel: 'C123456',
+        timestamp: '1234567890.123456',
+      });
+    });
+
+    it('should handle channel ID directly', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.add.mockResolvedValue({ ok: true });
+
+      await pinOps.addPin('C123456', '1234567890.123456');
+
+      expect(mockClient.pins.add).toHaveBeenCalledWith({
+        channel: 'C123456',
+        timestamp: '1234567890.123456',
+      });
+    });
+
+    it('should throw when pin add fails', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.add.mockRejectedValue(new Error('already_pinned'));
+
+      await expect(pinOps.addPin('general', '1234567890.123456')).rejects.toThrow('already_pinned');
+    });
+  });
+
+  describe('removePin', () => {
+    it('should remove a pin from a message', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.remove.mockResolvedValue({ ok: true });
+
+      await pinOps.removePin('general', '1234567890.123456');
+
+      expect(mockClient.pins.remove).toHaveBeenCalledWith({
+        channel: 'C123456',
+        timestamp: '1234567890.123456',
+      });
+    });
+
+    it('should throw when pin remove fails', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.remove.mockRejectedValue(new Error('no_pin'));
+
+      await expect(pinOps.removePin('general', '1234567890.123456')).rejects.toThrow('no_pin');
+    });
+  });
+
+  describe('listPins', () => {
+    it('should list pinned items in a channel', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.list.mockResolvedValue({
+        ok: true,
+        items: [
+          {
+            type: 'message',
+            created: 1700000000,
+            created_by: 'U123',
+            message: {
+              text: 'Pinned message 1',
+              user: 'U123',
+              ts: '1234567890.123456',
+            },
+          },
+          {
+            type: 'message',
+            created: 1700000100,
+            created_by: 'U456',
+            message: {
+              text: 'Pinned message 2',
+              user: 'U456',
+              ts: '1234567891.123456',
+            },
+          },
+        ],
+      });
+
+      const result = await pinOps.listPins('general');
+
+      expect(channelResolver.resolveChannelId).toHaveBeenCalledWith(
+        'general',
+        expect.any(Function)
+      );
+      expect(mockClient.pins.list).toHaveBeenCalledWith({
+        channel: 'C123456',
+      });
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({
+        type: 'message',
+        created: 1700000000,
+        created_by: 'U123',
+        message: {
+          text: 'Pinned message 1',
+          user: 'U123',
+          ts: '1234567890.123456',
+        },
+      });
+    });
+
+    it('should return empty array when no pins exist', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.list.mockResolvedValue({
+        ok: true,
+        items: [],
+      });
+
+      const result = await pinOps.listPins('general');
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when items is undefined', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456');
+      mockClient.pins.list.mockResolvedValue({
+        ok: true,
+      });
+
+      const result = await pinOps.listPins('general');
+
+      expect(result).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `pin add`, `pin remove`, and `pin list` subcommands (#136)
- Support table/simple/json output formats for `pin list`
- Timestamp validation and channel name resolution
- 21 new tests (391 total)
- Bump version to 0.10.0

## Usage

```bash
# Pin a message
slack-cli pin add -c general -t 1234567890.123456

# Unpin a message
slack-cli pin remove -c general -t 1234567890.123456

# List pinned items
slack-cli pin list -c general
slack-cli pin list -c general --format json
```

## Test plan

- [x] pin add sends correct API call with channel resolution
- [x] pin remove sends correct API call
- [x] pin list returns items in all formats (table/simple/json)
- [x] Timestamp validation rejects invalid formats
- [x] Error handling for already_pinned, no_pin, missing config
- [x] Profile support works for all subcommands
- [x] All 391 tests pass