### PR TITLE
feat: add channel command for topic, purpose, and info management

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ slack-cli channels --format json
 slack-cli channels --format simple
 ```
 
+### Channel Info & Management
+
+```bash
+# Display channel details (topic, purpose, members, etc.)
+slack-cli channel info -c general
+
+# Output channel info in different formats
+slack-cli channel info -c general --format json
+slack-cli channel info -c general --format simple
+
+# Set channel topic
+slack-cli channel set-topic -c general --topic "Current sprint: v2.0"
+
+# Set channel purpose
+slack-cli channel set-purpose -c general --purpose "Project X development channel"
+```
+
 ### View Message History
 
 ```bash
@@ -468,8 +485,10 @@ Subcommands: `list`, `cancel`
 Your Slack API token needs the following scopes:
 
 - `chat:write` - Send and edit messages
-- `channels:read` - List public channels
-- `groups:read` - List private channels
+- `channels:read` - List public channels and get channel info
+- `channels:write` - Set topic/purpose for public channels
+- `groups:read` - List private channels and get channel info
+- `groups:write` - Set topic/purpose for private channels
 - `channels:history` - Read channel message history
 - `groups:history` - Read private channel message history
 - `im:history` - Read direct message history

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/channel.ts
+++ b/src/commands/channel.ts
@@ -1,0 +1,70 @@
+import { Command } from 'commander';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import {
+  ChannelInfoOptions,
+  ChannelSetTopicOptions,
+  ChannelSetPurposeOptions,
+} from '../types/commands';
+import { parseFormat, parseProfile } from '../utils/option-parsers';
+import { createChannelInfoFormatter } from '../utils/formatters/channel-info-formatters';
+import { createValidationHook, optionValidators } from '../utils/validators';
+
+export function setupChannelCommand(): Command {
+  const channelCommand = new Command('channel').description(
+    'Manage channel topic, purpose, and info'
+  );
+
+  channelCommand
+    .command('info')
+    .description('Display channel details including topic and purpose')
+    .requiredOption('-c, --channel <channel>', 'Target channel name or ID')
+    .option('--format <format>', 'Output format: table, simple, json', 'table')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.format]))
+    .action(
+      wrapCommand(async (options: ChannelInfoOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        const channel = await client.getChannelDetail(options.channel);
+        const format = parseFormat(options.format);
+        const formatter = createChannelInfoFormatter(format);
+        formatter.format({ channel });
+      })
+    );
+
+  channelCommand
+    .command('set-topic')
+    .description('Set the topic of a channel')
+    .requiredOption('-c, --channel <channel>', 'Target channel name or ID')
+    .requiredOption('--topic <topic>', 'New topic text')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .action(
+      wrapCommand(async (options: ChannelSetTopicOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.setTopic(options.channel, options.topic);
+        console.log(`✓ Topic updated for #${options.channel}`);
+      })
+    );
+
+  channelCommand
+    .command('set-purpose')
+    .description('Set the purpose of a channel')
+    .requiredOption('-c, --channel <channel>', 'Target channel name or ID')
+    .requiredOption('--purpose <purpose>', 'New purpose text')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .action(
+      wrapCommand(async (options: ChannelSetPurposeOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.setPurpose(options.channel, options.purpose);
+        console.log(`✓ Purpose updated for #${options.channel}`);
+      })
+    );
+
+  return channelCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { setupUploadCommand } from './commands/upload';
 import { setupReactionCommand } from './commands/reaction';
 import { setupPinCommand } from './commands/pin';
 import { setupUsersCommand } from './commands/users';
+import { setupChannelCommand } from './commands/channel';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -37,5 +38,6 @@ program.addCommand(setupUploadCommand());
 program.addCommand(setupReactionCommand());
 program.addCommand(setupPinCommand());
 program.addCommand(setupUsersCommand());
+program.addCommand(setupChannelCommand());
 
 program.parse();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -127,6 +127,24 @@ export interface UsersLookupOptions {
   profile?: string;
 }
 
+export interface ChannelInfoOptions {
+  channel: string;
+  format?: 'table' | 'simple' | 'json';
+  profile?: string;
+}
+
+export interface ChannelSetTopicOptions {
+  channel: string;
+  topic: string;
+  profile?: string;
+}
+
+export interface ChannelSetPurposeOptions {
+  channel: string;
+  purpose: string;
+  profile?: string;
+}
+
 export interface SearchOptions {
   query: string;
   sort?: 'score' | 'timestamp';

--- a/src/utils/formatters/channel-info-formatters.ts
+++ b/src/utils/formatters/channel-info-formatters.ts
@@ -1,0 +1,69 @@
+import chalk from 'chalk';
+import { AbstractFormatter, JsonFormatter, createFormatterFactory } from './base-formatter';
+import { ChannelDetail } from '../slack-api-client';
+
+export interface ChannelInfoFormatterOptions {
+  channel: ChannelDetail;
+}
+
+class TableChannelInfoFormatter extends AbstractFormatter<ChannelInfoFormatterOptions> {
+  format(options: ChannelInfoFormatterOptions): void {
+    const { channel } = options;
+
+    console.log(chalk.bold(`\nChannel Info: #${channel.name}`));
+    console.log('');
+    console.log(`  ${chalk.gray('ID:')}       ${channel.id}`);
+    console.log(`  ${chalk.gray('Name:')}     ${channel.name}`);
+    console.log(`  ${chalk.gray('Private:')}  ${channel.is_private ? 'Yes' : 'No'}`);
+    console.log(`  ${chalk.gray('Archived:')} ${channel.is_archived ? 'Yes' : 'No'}`);
+    if (channel.num_members !== undefined) {
+      console.log(`  ${chalk.gray('Members:')}  ${channel.num_members}`);
+    }
+    console.log(
+      `  ${chalk.gray('Created:')}  ${new Date(channel.created * 1000).toLocaleDateString()}`
+    );
+    console.log('');
+    console.log(`  ${chalk.gray('Topic:')}    ${channel.topic?.value || '(not set)'}`);
+    console.log(`  ${chalk.gray('Purpose:')}  ${channel.purpose?.value || '(not set)'}`);
+    console.log('');
+  }
+}
+
+class SimpleChannelInfoFormatter extends AbstractFormatter<ChannelInfoFormatterOptions> {
+  format(options: ChannelInfoFormatterOptions): void {
+    const { channel } = options;
+
+    console.log(`${channel.name} (${channel.id})`);
+    console.log(`Topic: ${channel.topic?.value || '(not set)'}`);
+    console.log(`Purpose: ${channel.purpose?.value || '(not set)'}`);
+    if (channel.num_members !== undefined) {
+      console.log(`Members: ${channel.num_members}`);
+    }
+  }
+}
+
+class JsonChannelInfoFormatter extends JsonFormatter<ChannelInfoFormatterOptions> {
+  protected transform(options: ChannelInfoFormatterOptions) {
+    const { channel } = options;
+    return {
+      id: channel.id,
+      name: channel.name,
+      is_private: channel.is_private,
+      is_archived: channel.is_archived ?? false,
+      created: channel.created,
+      num_members: channel.num_members,
+      topic: channel.topic?.value || null,
+      purpose: channel.purpose?.value || null,
+    };
+  }
+}
+
+const channelInfoFormatterFactory = createFormatterFactory<ChannelInfoFormatterOptions>({
+  table: new TableChannelInfoFormatter(),
+  simple: new SimpleChannelInfoFormatter(),
+  json: new JsonChannelInfoFormatter(),
+});
+
+export function createChannelInfoFormatter(format: string) {
+  return channelInfoFormatterFactory.create(format);
+}

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -51,6 +51,25 @@ export interface Channel {
   };
 }
 
+export interface ChannelDetail {
+  id: string;
+  name: string;
+  is_private: boolean;
+  is_archived?: boolean;
+  created: number;
+  num_members?: number;
+  topic?: {
+    value: string;
+    creator?: string;
+    last_set?: number;
+  };
+  purpose?: {
+    value: string;
+    creator?: string;
+    last_set?: number;
+  };
+}
+
 export interface ListChannelsOptions {
   types: string;
   exclude_archived: boolean;
@@ -147,6 +166,18 @@ export class SlackApiClient {
 
   async listChannels(options: ListChannelsOptions): Promise<Channel[]> {
     return this.channelOps.listChannels(options);
+  }
+
+  async getChannelDetail(channelNameOrId: string): Promise<ChannelDetail> {
+    return this.channelOps.getChannelDetail(channelNameOrId);
+  }
+
+  async setTopic(channelNameOrId: string, topic: string): Promise<void> {
+    return this.channelOps.setTopic(channelNameOrId, topic);
+  }
+
+  async setPurpose(channelNameOrId: string, purpose: string): Promise<void> {
+    return this.channelOps.setPurpose(channelNameOrId, purpose);
   }
 
   async getHistory(channel: string, options: HistoryOptions): Promise<HistoryResult> {

--- a/src/utils/slack-operations/channel-operations.ts
+++ b/src/utils/slack-operations/channel-operations.ts
@@ -1,7 +1,7 @@
 import { BaseSlackClient } from './base-client';
 import { channelResolver } from '../channel-resolver';
 import { DEFAULTS } from '../constants';
-import { Channel, ListChannelsOptions, Message } from '../slack-api-client';
+import { Channel, ChannelDetail, ListChannelsOptions, Message } from '../slack-api-client';
 import { WebClient } from '@slack/web-api';
 
 interface ChannelWithUnreadInfo extends Channel {
@@ -159,5 +159,52 @@ export class ChannelOperations extends BaseSlackClient {
     });
 
     return info.channel as ChannelWithUnreadInfo;
+  }
+
+  async getChannelDetail(channelNameOrId: string): Promise<ChannelDetail> {
+    const channelId = await channelResolver.resolveChannelId(channelNameOrId, () =>
+      this.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    const info = await this.client.conversations.info({
+      channel: channelId,
+      include_num_members: true,
+    });
+
+    return info.channel as ChannelDetail;
+  }
+
+  async setTopic(channelNameOrId: string, topic: string): Promise<void> {
+    const channelId = await channelResolver.resolveChannelId(channelNameOrId, () =>
+      this.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    await this.client.conversations.setTopic({
+      channel: channelId,
+      topic,
+    });
+  }
+
+  async setPurpose(channelNameOrId: string, purpose: string): Promise<void> {
+    const channelId = await channelResolver.resolveChannelId(channelNameOrId, () =>
+      this.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    await this.client.conversations.setPurpose({
+      channel: channelId,
+      purpose,
+    });
   }
 }

--- a/tests/commands/channel.test.ts
+++ b/tests/commands/channel.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupChannelCommand } from '../../src/commands/channel';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('channel command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupChannelCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('info subcommand', () => {
+    it('should display channel info in table format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getChannelDetail).mockResolvedValue({
+        id: 'C1234567890',
+        name: 'general',
+        is_private: false,
+        is_archived: false,
+        created: 1579075200,
+        num_members: 42,
+        topic: { value: 'Current topic', creator: 'U111', last_set: 1700000000 },
+        purpose: { value: 'Current purpose', creator: 'U222', last_set: 1700000001 },
+      });
+
+      await program.parseAsync(['node', 'slack-cli', 'channel', 'info', '-c', 'general']);
+
+      expect(mockSlackClient.getChannelDetail).toHaveBeenCalledWith('general');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('general'));
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Current topic'));
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Current purpose'));
+    });
+
+    it('should display channel info in json format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getChannelDetail).mockResolvedValue({
+        id: 'C1234567890',
+        name: 'general',
+        is_private: false,
+        created: 1579075200,
+        num_members: 10,
+        topic: { value: 'Topic here' },
+        purpose: { value: 'Purpose here' },
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'channel',
+        'info',
+        '-c',
+        'general',
+        '--format',
+        'json',
+      ]);
+
+      const logCall = mockConsole.logSpy.mock.calls.find((call: any[]) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(logCall).toBeDefined();
+      const output = JSON.parse(logCall![0]);
+      expect(output.name).toBe('general');
+      expect(output.topic).toBe('Topic here');
+      expect(output.purpose).toBe('Purpose here');
+    });
+
+    it('should display channel info in simple format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getChannelDetail).mockResolvedValue({
+        id: 'C1234567890',
+        name: 'general',
+        is_private: false,
+        created: 1579075200,
+        num_members: 10,
+        topic: { value: 'Topic here' },
+        purpose: { value: 'Purpose here' },
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'channel',
+        'info',
+        '-c',
+        'general',
+        '--format',
+        'simple',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('general'));
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Topic here'));
+    });
+
+    it('should handle missing topic and purpose', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getChannelDetail).mockResolvedValue({
+        id: 'C1234567890',
+        name: 'empty-channel',
+        is_private: false,
+        created: 1579075200,
+      });
+
+      await program.parseAsync(['node', 'slack-cli', 'channel', 'info', '-c', 'empty-channel']);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('empty-channel'));
+    });
+  });
+
+  describe('set-topic subcommand', () => {
+    it('should set channel topic successfully', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.setTopic).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'channel',
+        'set-topic',
+        '-c',
+        'general',
+        '--topic',
+        'New topic',
+      ]);
+
+      expect(mockSlackClient.setTopic).toHaveBeenCalledWith('general', 'New topic');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('general'));
+    });
+
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.setTopic).mockRejectedValue(new Error('not_in_channel'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'channel',
+        'set-topic',
+        '-c',
+        'general',
+        '--topic',
+        'New topic',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith('✗ Error:', 'not_in_channel');
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.setTopic).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'channel',
+        'set-topic',
+        '-c',
+        'general',
+        '--topic',
+        'Test',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+    });
+  });
+
+  describe('set-purpose subcommand', () => {
+    it('should set channel purpose successfully', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.setPurpose).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'channel',
+        'set-purpose',
+        '-c',
+        'general',
+        '--purpose',
+        'New purpose',
+      ]);
+
+      expect(mockSlackClient.setPurpose).toHaveBeenCalledWith('general', 'New purpose');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('general'));
+    });
+
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.setPurpose).mockRejectedValue(
+        new Error('channel_not_found')
+      );
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'channel',
+        'set-purpose',
+        '-c',
+        'unknown',
+        '--purpose',
+        'New purpose',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith('✗ Error:', 'channel_not_found');
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/utils/slack-operations/channel-topic-operations.test.ts
+++ b/tests/utils/slack-operations/channel-topic-operations.test.ts
@@ -1,0 +1,149 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ChannelOperations } from '../../../src/utils/slack-operations/channel-operations';
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    conversations: {
+      list: vi.fn(),
+      info: vi.fn(),
+      history: vi.fn(),
+      setTopic: vi.fn(),
+      setPurpose: vi.fn(),
+    },
+  })),
+  LogLevel: {
+    ERROR: 'error',
+  },
+}));
+
+vi.mock('p-limit', () => ({
+  default: () => (fn: any) => fn(),
+}));
+
+describe('ChannelOperations - topic/purpose', () => {
+  let channelOps: ChannelOperations;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = {
+      conversations: {
+        list: vi.fn(),
+        info: vi.fn(),
+        history: vi.fn(),
+        setTopic: vi.fn(),
+        setPurpose: vi.fn(),
+      },
+    };
+    channelOps = new ChannelOperations('test-token');
+    (channelOps as any).client = mockClient;
+  });
+
+  describe('setTopic', () => {
+    it('should set channel topic with channel name resolution', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [{ id: 'C123', name: 'general' }],
+      });
+      mockClient.conversations.setTopic.mockResolvedValue({
+        ok: true,
+        channel: { id: 'C123', topic: { value: 'New topic' } },
+      });
+
+      await channelOps.setTopic('general', 'New topic');
+
+      expect(mockClient.conversations.setTopic).toHaveBeenCalledWith({
+        channel: 'C123',
+        topic: 'New topic',
+      });
+    });
+
+    it('should set topic with channel ID directly', async () => {
+      mockClient.conversations.setTopic.mockResolvedValue({
+        ok: true,
+        channel: { id: 'C1234567890', topic: { value: 'Updated topic' } },
+      });
+
+      await channelOps.setTopic('C1234567890', 'Updated topic');
+
+      expect(mockClient.conversations.setTopic).toHaveBeenCalledWith({
+        channel: 'C1234567890',
+        topic: 'Updated topic',
+      });
+      // Should not call list when given a channel ID
+      expect(mockClient.conversations.list).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setPurpose', () => {
+    it('should set channel purpose with channel name resolution', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [{ id: 'C456', name: 'random' }],
+      });
+      mockClient.conversations.setPurpose.mockResolvedValue({
+        ok: true,
+        channel: { id: 'C456', purpose: { value: 'New purpose' } },
+      });
+
+      await channelOps.setPurpose('random', 'New purpose');
+
+      expect(mockClient.conversations.setPurpose).toHaveBeenCalledWith({
+        channel: 'C456',
+        purpose: 'New purpose',
+      });
+    });
+  });
+
+  describe('getChannelDetail', () => {
+    it('should return channel detail with topic, purpose, and member count', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [{ id: 'C123', name: 'general' }],
+      });
+      mockClient.conversations.info.mockResolvedValue({
+        channel: {
+          id: 'C123',
+          name: 'general',
+          is_private: false,
+          is_archived: false,
+          created: 1579075200,
+          num_members: 42,
+          topic: { value: 'Current topic', creator: 'U111', last_set: 1700000000 },
+          purpose: { value: 'Current purpose', creator: 'U222', last_set: 1700000001 },
+        },
+      });
+
+      const result = await channelOps.getChannelDetail('general');
+
+      expect(result).toEqual({
+        id: 'C123',
+        name: 'general',
+        is_private: false,
+        is_archived: false,
+        created: 1579075200,
+        num_members: 42,
+        topic: { value: 'Current topic', creator: 'U111', last_set: 1700000000 },
+        purpose: { value: 'Current purpose', creator: 'U222', last_set: 1700000001 },
+      });
+    });
+
+    it('should include num_members in the API call', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [{ id: 'C123', name: 'general' }],
+      });
+      mockClient.conversations.info.mockResolvedValue({
+        channel: {
+          id: 'C123',
+          name: 'general',
+          is_private: false,
+          created: 1579075200,
+        },
+      });
+
+      await channelOps.getChannelDetail('general');
+
+      expect(mockClient.conversations.info).toHaveBeenCalledWith({
+        channel: 'C123',
+        include_num_members: true,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `channel info` サブコマンドでチャンネル詳細（topic, purpose, メンバー数等）を表示
- `channel set-topic` サブコマンドでチャンネルのtopicを更新
- `channel set-purpose` サブコマンドでチャンネルのpurposeを更新
- 全サブコマンドでチャンネル名解決・プロファイル指定に対応

## Changes
- `src/commands/channel.ts` (NEW) - channel コマンド（info / set-topic / set-purpose）
- `src/utils/formatters/channel-info-formatters.ts` (NEW) - table/simple/json フォーマッター
- `src/utils/slack-operations/channel-operations.ts` - getChannelDetail, setTopic, setPurpose メソッド追加
- `src/utils/slack-api-client.ts` - ChannelDetail インターフェース、ファサードメソッド追加
- `src/types/commands.ts` - ChannelInfoOptions, ChannelSetTopicOptions, ChannelSetPurposeOptions 追加
- `src/index.ts` - channel コマンド登録

## Test plan
- [x] channel operations ユニットテスト (5 tests)
- [x] channel コマンドテスト (9 tests)
- [x] 全438テストパス
- [x] build / lint / format チェックパス

Closes #137