### PR TITLE
feat: support conversations.members (channel member listing)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/members.ts
+++ b/src/commands/members.ts
@@ -1,0 +1,60 @@
+import { Command } from 'commander';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import { MembersOptions } from '../types/commands';
+import { parseFormat, parseLimit, parseProfile } from '../utils/option-parsers';
+import { createValidationHook, optionValidators } from '../utils/validators';
+import { createMembersFormatter, MemberInfo } from '../utils/formatters/members-formatters';
+
+export function setupMembersCommand(): Command {
+  const membersCommand = new Command('members');
+
+  membersCommand
+    .description('List channel members')
+    .requiredOption('-c, --channel <channel>', 'Target channel name or ID')
+    .option('--limit <number>', 'Maximum number of members to list', '100')
+    .option('--format <format>', 'Output format: table, simple, json', 'table')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([optionValidators.format]))
+    .action(
+      wrapCommand(async (options: MembersOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+        const limit = parseLimit(options.limit, 100);
+
+        const result = await client.getChannelMembers(options.channel, { limit });
+
+        if (result.members.length === 0) {
+          console.log('No members found');
+          return;
+        }
+
+        // Resolve user names for each member
+        const memberInfos: MemberInfo[] = await Promise.all(
+          result.members.map(async (userId) => {
+            try {
+              const user = await client.getUserInfo(userId);
+              return {
+                id: userId,
+                name: user.name,
+                realName: user.real_name,
+              };
+            } catch {
+              // If user lookup fails, return ID only
+              return {
+                id: userId,
+                name: undefined,
+                realName: undefined,
+              };
+            }
+          })
+        );
+
+        const format = parseFormat(options.format);
+        const formatter = createMembersFormatter(format);
+        formatter.format({ members: memberInfos });
+      })
+    );
+
+  return membersCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { setupReactionCommand } from './commands/reaction';
 import { setupPinCommand } from './commands/pin';
 import { setupUsersCommand } from './commands/users';
 import { setupChannelCommand } from './commands/channel';
+import { setupMembersCommand } from './commands/members';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -39,5 +40,6 @@ program.addCommand(setupReactionCommand());
 program.addCommand(setupPinCommand());
 program.addCommand(setupUsersCommand());
 program.addCommand(setupChannelCommand());
+program.addCommand(setupMembersCommand());
 
 program.parse();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -154,6 +154,13 @@ export interface ChannelSetPurposeOptions {
   profile?: string;
 }
 
+export interface MembersOptions {
+  channel: string;
+  limit?: string;
+  format?: 'table' | 'simple' | 'json';
+  profile?: string;
+}
+
 export interface SearchOptions {
   query: string;
   sort?: 'score' | 'timestamp';

--- a/src/utils/formatters/members-formatters.ts
+++ b/src/utils/formatters/members-formatters.ts
@@ -1,0 +1,54 @@
+import { AbstractFormatter, JsonFormatter, createFormatterFactory } from './base-formatter';
+
+export interface MemberInfo {
+  id: string;
+  name?: string;
+  realName?: string;
+}
+
+export interface MembersFormatterOptions {
+  members: MemberInfo[];
+}
+
+class MembersTableFormatter extends AbstractFormatter<MembersFormatterOptions> {
+  format({ members }: MembersFormatterOptions): void {
+    console.log('ID                Name              Real Name');
+    console.log('\u2500'.repeat(60));
+
+    members.forEach((member) => {
+      const id = (member.id || '').padEnd(17);
+      const name = (member.name || '').padEnd(17);
+      const realName = member.realName || '';
+
+      console.log(`${id} ${name} ${realName}`);
+    });
+  }
+}
+
+class MembersSimpleFormatter extends AbstractFormatter<MembersFormatterOptions> {
+  format({ members }: MembersFormatterOptions): void {
+    members.forEach((member) => {
+      console.log(`${member.id || ''}\t${member.name || ''}\t${member.realName || ''}`);
+    });
+  }
+}
+
+class MembersJsonFormatter extends JsonFormatter<MembersFormatterOptions> {
+  protected transform({ members }: MembersFormatterOptions) {
+    return members.map((member) => ({
+      id: member.id,
+      name: member.name || '',
+      real_name: member.realName || '',
+    }));
+  }
+}
+
+const membersFormatterFactory = createFormatterFactory<MembersFormatterOptions>({
+  table: new MembersTableFormatter(),
+  simple: new MembersSimpleFormatter(),
+  json: new MembersJsonFormatter(),
+});
+
+export function createMembersFormatter(format: string) {
+  return membersFormatterFactory.create(format);
+}

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -3,7 +3,11 @@ import {
   ChatScheduleMessageResponse,
   ChatUpdateResponse,
 } from '@slack/web-api';
-import { ChannelOperations } from './slack-operations/channel-operations';
+import {
+  ChannelOperations,
+  ChannelMembersOptions,
+  ChannelMembersResult,
+} from './slack-operations/channel-operations';
 import { MessageOperations } from './slack-operations/message-operations';
 import { FileOperations, UploadFileOptions } from './slack-operations/file-operations';
 import { ReactionOperations } from './slack-operations/reaction-operations';
@@ -23,6 +27,8 @@ export type {
   PinnedItem,
   SlackUser,
   UserPresence,
+  ChannelMembersOptions,
+  ChannelMembersResult,
 };
 
 export interface Channel {
@@ -265,6 +271,13 @@ export class SlackApiClient {
 
   async searchMessages(query: string, options?: SearchMessagesOptions): Promise<SearchResult> {
     return this.searchOps.searchMessages(query, options);
+  }
+
+  async getChannelMembers(
+    channelNameOrId: string,
+    options?: ChannelMembersOptions
+  ): Promise<ChannelMembersResult> {
+    return this.channelOps.getChannelMembers(channelNameOrId, options);
   }
 }
 

--- a/src/utils/slack-operations/channel-operations.ts
+++ b/src/utils/slack-operations/channel-operations.ts
@@ -4,6 +4,16 @@ import { DEFAULTS } from '../constants';
 import { Channel, ChannelDetail, ListChannelsOptions, Message } from '../slack-api-client';
 import { WebClient } from '@slack/web-api';
 
+export interface ChannelMembersOptions {
+  limit?: number;
+  cursor?: string;
+}
+
+export interface ChannelMembersResult {
+  members: string[];
+  nextCursor: string;
+}
+
 interface ChannelWithUnreadInfo extends Channel {
   unread_count: number;
   unread_count_display: number;
@@ -206,5 +216,29 @@ export class ChannelOperations extends BaseSlackClient {
       channel: channelId,
       purpose,
     });
+  }
+
+  async getChannelMembers(
+    channelNameOrId: string,
+    options: ChannelMembersOptions = {}
+  ): Promise<ChannelMembersResult> {
+    const channelId = await channelResolver.resolveChannelId(channelNameOrId, () =>
+      this.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    const response = await this.client.conversations.members({
+      channel: channelId,
+      limit: options.limit ?? 100,
+      cursor: options.cursor,
+    });
+
+    return {
+      members: (response.members as string[]) || [],
+      nextCursor: response.response_metadata?.next_cursor || '',
+    };
   }
 }

--- a/tests/commands/members.test.ts
+++ b/tests/commands/members.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupMembersCommand } from '../../src/commands/members';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('members command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupMembersCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('basic functionality', () => {
+    it('should list channel members in table format by default', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockResolvedValue({
+        members: ['U01ABCDEF', 'U02GHIJKL'],
+        nextCursor: '',
+      });
+      vi.mocked(mockSlackClient.getUserInfo).mockImplementation(async (userId: string) => {
+        const users: Record<string, any> = {
+          U01ABCDEF: { id: 'U01ABCDEF', name: 'alice', real_name: 'Alice Smith' },
+          U02GHIJKL: { id: 'U02GHIJKL', name: 'bob', real_name: 'Bob Jones' },
+        };
+        return users[userId];
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+      ]);
+
+      expect(mockSlackClient.getChannelMembers).toHaveBeenCalledWith('C1234567890', {
+        limit: 100,
+      });
+      expect(mockConsole.logSpy).toHaveBeenCalled();
+    });
+
+    it('should list channel members in json format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockResolvedValue({
+        members: ['U01ABCDEF'],
+        nextCursor: '',
+      });
+      vi.mocked(mockSlackClient.getUserInfo).mockResolvedValue({
+        id: 'U01ABCDEF',
+        name: 'alice',
+        real_name: 'Alice Smith',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+        '--format',
+        'json',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('"id": "U01ABCDEF"')
+      );
+    });
+
+    it('should list channel members in simple format', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockResolvedValue({
+        members: ['U01ABCDEF'],
+        nextCursor: '',
+      });
+      vi.mocked(mockSlackClient.getUserInfo).mockResolvedValue({
+        id: 'U01ABCDEF',
+        name: 'alice',
+        real_name: 'Alice Smith',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+        '--format',
+        'simple',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('U01ABCDEF')
+      );
+    });
+
+    it('should show message when no members found', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockResolvedValue({
+        members: [],
+        nextCursor: '',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('No members found');
+    });
+  });
+
+  describe('options', () => {
+    it('should respect limit option', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockResolvedValue({
+        members: ['U01ABCDEF'],
+        nextCursor: '',
+      });
+      vi.mocked(mockSlackClient.getUserInfo).mockResolvedValue({
+        id: 'U01ABCDEF',
+        name: 'alice',
+        real_name: 'Alice Smith',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+        '--limit',
+        '50',
+      ]);
+
+      expect(mockSlackClient.getChannelMembers).toHaveBeenCalledWith('C1234567890', {
+        limit: 50,
+      });
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockResolvedValue({
+        members: [],
+        nextCursor: '',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle API errors gracefully', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockRejectedValue(
+        new Error('channel_not_found')
+      );
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'CINVALID',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should gracefully handle user info resolution failures', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.getChannelMembers).mockResolvedValue({
+        members: ['U01ABCDEF', 'U02GHIJKL'],
+        nextCursor: '',
+      });
+      vi.mocked(mockSlackClient.getUserInfo)
+        .mockResolvedValueOnce({
+          id: 'U01ABCDEF',
+          name: 'alice',
+          real_name: 'Alice Smith',
+        })
+        .mockRejectedValueOnce(new Error('user_not_found'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'members',
+        '-c',
+        'C1234567890',
+      ]);
+
+      // Should still succeed - failed user lookups show ID only
+      expect(mockConsole.logSpy).toHaveBeenCalled();
+      expect(mockConsole.exitSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/utils/formatters/members-formatters.test.ts
+++ b/tests/utils/formatters/members-formatters.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  createMembersFormatter,
+  MembersFormatterOptions,
+} from '../../../src/utils/formatters/members-formatters';
+
+describe('members formatters', () => {
+  let logSpy: any;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const sampleMembers: MembersFormatterOptions = {
+    members: [
+      { id: 'U01ABCDEF', name: 'alice', realName: 'Alice Smith' },
+      { id: 'U02GHIJKL', name: 'bob', realName: 'Bob Jones' },
+      { id: 'U03MNOPQR', name: undefined, realName: undefined },
+    ],
+  };
+
+  describe('table format', () => {
+    it('should render members in table format with header', () => {
+      const formatter = createMembersFormatter('table');
+      formatter.format(sampleMembers);
+
+      // Should have header line and separator
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('ID'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Name'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Real Name'));
+
+      // Should have data rows
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('U01ABCDEF'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('alice'));
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('Alice Smith'));
+    });
+
+    it('should handle members with no name/realName', () => {
+      const formatter = createMembersFormatter('table');
+      formatter.format({
+        members: [{ id: 'U03MNOPQR', name: undefined, realName: undefined }],
+      });
+
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('U03MNOPQR'));
+    });
+  });
+
+  describe('simple format', () => {
+    it('should render members in simple tab-separated format', () => {
+      const formatter = createMembersFormatter('simple');
+      formatter.format(sampleMembers);
+
+      expect(logSpy).toHaveBeenCalledWith('U01ABCDEF\talice\tAlice Smith');
+      expect(logSpy).toHaveBeenCalledWith('U02GHIJKL\tbob\tBob Jones');
+      expect(logSpy).toHaveBeenCalledWith('U03MNOPQR\t\t');
+    });
+  });
+
+  describe('json format', () => {
+    it('should render members as JSON', () => {
+      const formatter = createMembersFormatter('json');
+      formatter.format(sampleMembers);
+
+      const expected = JSON.stringify(
+        [
+          { id: 'U01ABCDEF', name: 'alice', real_name: 'Alice Smith' },
+          { id: 'U02GHIJKL', name: 'bob', real_name: 'Bob Jones' },
+          { id: 'U03MNOPQR', name: '', real_name: '' },
+        ],
+        null,
+        2
+      );
+      expect(logSpy).toHaveBeenCalledWith(expected);
+    });
+  });
+
+  describe('factory', () => {
+    it('should default to table format for unknown format', () => {
+      const formatter = createMembersFormatter('unknown');
+      formatter.format(sampleMembers);
+
+      // Should render as table (with header)
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('ID'));
+    });
+  });
+});

--- a/tests/utils/slack-operations/channel-members-operations.test.ts
+++ b/tests/utils/slack-operations/channel-members-operations.test.ts
@@ -1,0 +1,147 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ChannelOperations } from '../../../src/utils/slack-operations/channel-operations';
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    conversations: {
+      list: vi.fn(),
+      info: vi.fn(),
+      history: vi.fn(),
+      members: vi.fn(),
+    },
+  })),
+  LogLevel: {
+    ERROR: 'error',
+  },
+}));
+
+vi.mock('p-limit', () => ({
+  default: () => (fn: any) => fn(),
+}));
+
+describe('ChannelOperations - getChannelMembers', () => {
+  let channelOps: ChannelOperations;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = {
+      conversations: {
+        list: vi.fn(),
+        info: vi.fn(),
+        history: vi.fn(),
+        members: vi.fn(),
+      },
+    };
+    channelOps = new ChannelOperations('test-token');
+    (channelOps as any).client = mockClient;
+  });
+
+  it('should return member IDs for a channel', async () => {
+    mockClient.conversations.members.mockResolvedValue({
+      ok: true,
+      members: ['U01ABCDEF', 'U02GHIJKL'],
+      response_metadata: { next_cursor: '' },
+    });
+
+    const result = await channelOps.getChannelMembers('C1234567890');
+
+    expect(result.members).toEqual(['U01ABCDEF', 'U02GHIJKL']);
+    expect(result.nextCursor).toBe('');
+    expect(mockClient.conversations.members).toHaveBeenCalledWith({
+      channel: 'C1234567890',
+      limit: 100,
+      cursor: undefined,
+    });
+  });
+
+  it('should pass limit parameter', async () => {
+    mockClient.conversations.members.mockResolvedValue({
+      ok: true,
+      members: ['U01ABCDEF'],
+      response_metadata: { next_cursor: '' },
+    });
+
+    await channelOps.getChannelMembers('C1234567890', { limit: 50 });
+
+    expect(mockClient.conversations.members).toHaveBeenCalledWith({
+      channel: 'C1234567890',
+      limit: 50,
+      cursor: undefined,
+    });
+  });
+
+  it('should pass cursor for pagination', async () => {
+    mockClient.conversations.members.mockResolvedValue({
+      ok: true,
+      members: ['U03MNOPQR'],
+      response_metadata: { next_cursor: '' },
+    });
+
+    await channelOps.getChannelMembers('C1234567890', {
+      cursor: 'dXNlcjpVMDYxTkZUVDI=',
+    });
+
+    expect(mockClient.conversations.members).toHaveBeenCalledWith({
+      channel: 'C1234567890',
+      limit: 100,
+      cursor: 'dXNlcjpVMDYxTkZUVDI=',
+    });
+  });
+
+  it('should return next_cursor when more pages exist', async () => {
+    mockClient.conversations.members.mockResolvedValue({
+      ok: true,
+      members: ['U01ABCDEF', 'U02GHIJKL'],
+      response_metadata: { next_cursor: 'dXNlcjpVMDYxTkZUVDI=' },
+    });
+
+    const result = await channelOps.getChannelMembers('C1234567890');
+
+    expect(result.members).toEqual(['U01ABCDEF', 'U02GHIJKL']);
+    expect(result.nextCursor).toBe('dXNlcjpVMDYxTkZUVDI=');
+  });
+
+  it('should return empty members array when channel has no members', async () => {
+    mockClient.conversations.members.mockResolvedValue({
+      ok: true,
+      members: [],
+      response_metadata: { next_cursor: '' },
+    });
+
+    const result = await channelOps.getChannelMembers('C1234567890');
+
+    expect(result.members).toEqual([]);
+    expect(result.nextCursor).toBe('');
+  });
+
+  it('should resolve channel name to ID before calling API', async () => {
+    mockClient.conversations.list.mockResolvedValue({
+      channels: [{ id: 'C1234567890', name: 'general' }],
+    });
+    mockClient.conversations.members.mockResolvedValue({
+      ok: true,
+      members: ['U01ABCDEF'],
+      response_metadata: { next_cursor: '' },
+    });
+
+    const result = await channelOps.getChannelMembers('general');
+
+    expect(result.members).toEqual(['U01ABCDEF']);
+    expect(mockClient.conversations.members).toHaveBeenCalledWith({
+      channel: 'C1234567890',
+      limit: 100,
+      cursor: undefined,
+    });
+  });
+
+  it('should propagate API errors', async () => {
+    mockClient.conversations.members.mockRejectedValue(
+      new Error('channel_not_found')
+    );
+
+    await expect(
+      channelOps.getChannelMembers('C1234567890')
+    ).rejects.toThrow('channel_not_found');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `members` command to list channel members via the Slack `conversations.members` API
- Supports `--channel` (required), `--limit`, `--format` (table/simple/json), and `--profile` options
- Resolves member user IDs to names/real names with graceful fallback on lookup failures
- Pagination support via cursor-based API calls

## Test plan
- [x] Unit tests for `ChannelOperations.getChannelMembers` (7 tests: basic, limit, cursor, pagination, empty, name resolution, error)
- [x] Unit tests for `members` command (9 tests: table/json/simple format, empty members, limit, profile, API errors, missing config, user info failures)
- [x] Unit tests for members formatters (5 tests: table/simple/json format, missing fields, factory fallback)
- [x] Full test suite passes (483 tests, 42 files)

Closes #107