### PR TITLE
feat: support conversations.join and conversations.leave

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/join.ts
+++ b/src/commands/join.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import { JoinOptions } from '../types/commands';
+import { parseProfile } from '../utils/option-parsers';
+
+export function setupJoinCommand(): Command {
+  const joinCommand = new Command('join')
+    .description('Join a channel')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .action(
+      wrapCommand(async (options: JoinOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.joinChannel(options.channel);
+        console.log(chalk.green(`✓ Joined channel #${options.channel}`));
+      })
+    );
+
+  return joinCommand;
+}

--- a/src/commands/leave.ts
+++ b/src/commands/leave.ts
@@ -1,0 +1,24 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { wrapCommand } from '../utils/command-wrapper';
+import { createSlackClient } from '../utils/client-factory';
+import { LeaveOptions } from '../types/commands';
+import { parseProfile } from '../utils/option-parsers';
+
+export function setupLeaveCommand(): Command {
+  const leaveCommand = new Command('leave')
+    .description('Leave a channel')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .action(
+      wrapCommand(async (options: LeaveOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        await client.leaveChannel(options.channel);
+        console.log(chalk.green(`✓ Left channel #${options.channel}`));
+      })
+    );
+
+  return leaveCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ import { setupUsersCommand } from './commands/users';
 import { setupChannelCommand } from './commands/channel';
 import { setupMembersCommand } from './commands/members';
 import { setupSendEphemeralCommand } from './commands/send-ephemeral';
+import { setupJoinCommand } from './commands/join';
+import { setupLeaveCommand } from './commands/leave';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
@@ -43,5 +45,7 @@ program.addCommand(setupUsersCommand());
 program.addCommand(setupChannelCommand());
 program.addCommand(setupMembersCommand());
 program.addCommand(setupSendEphemeralCommand());
+program.addCommand(setupJoinCommand());
+program.addCommand(setupLeaveCommand());
 
 program.parse();

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -169,6 +169,16 @@ export interface SendEphemeralOptions {
   profile?: string;
 }
 
+export interface JoinOptions {
+  channel: string;
+  profile?: string;
+}
+
+export interface LeaveOptions {
+  channel: string;
+  profile?: string;
+}
+
 export interface SearchOptions {
   query: string;
   sort?: 'score' | 'timestamp';

--- a/src/utils/slack-api-client.ts
+++ b/src/utils/slack-api-client.ts
@@ -283,6 +283,14 @@ export class SlackApiClient {
     return this.searchOps.searchMessages(query, options);
   }
 
+  async joinChannel(channelNameOrId: string): Promise<void> {
+    return this.channelOps.joinChannel(channelNameOrId);
+  }
+
+  async leaveChannel(channelNameOrId: string): Promise<void> {
+    return this.channelOps.leaveChannel(channelNameOrId);
+  }
+
   async getChannelMembers(
     channelNameOrId: string,
     options?: ChannelMembersOptions

--- a/src/utils/slack-operations/channel-operations.ts
+++ b/src/utils/slack-operations/channel-operations.ts
@@ -218,6 +218,34 @@ export class ChannelOperations extends BaseSlackClient {
     });
   }
 
+  async joinChannel(channelNameOrId: string): Promise<void> {
+    const channelId = await channelResolver.resolveChannelId(channelNameOrId, () =>
+      this.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    await this.client.conversations.join({
+      channel: channelId,
+    });
+  }
+
+  async leaveChannel(channelNameOrId: string): Promise<void> {
+    const channelId = await channelResolver.resolveChannelId(channelNameOrId, () =>
+      this.listChannels({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: DEFAULTS.CHANNELS_LIMIT,
+      })
+    );
+
+    await this.client.conversations.leave({
+      channel: channelId,
+    });
+  }
+
   async getChannelMembers(
     channelNameOrId: string,
     options: ChannelMembersOptions = {}

--- a/tests/commands/join.test.ts
+++ b/tests/commands/join.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupJoinCommand } from '../../src/commands/join';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('join command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupJoinCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('join channel', () => {
+    it('should join a channel', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.joinChannel).mockResolvedValue();
+
+      await program.parseAsync(['node', 'slack-cli', 'join', '-c', 'general']);
+
+      expect(mockSlackClient.joinChannel).toHaveBeenCalledWith('general');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Joined channel #general')
+      );
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.joinChannel).mockResolvedValue();
+
+      await program.parseAsync(['node', 'slack-cli', 'join', '-c', 'general', '--profile', 'work']);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync(['node', 'slack-cli', 'join', '-c', 'general']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle channel_not_found error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.joinChannel).mockRejectedValue(new Error('channel_not_found'));
+
+      await program.parseAsync(['node', 'slack-cli', 'join', '-c', 'nonexistent']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle is_archived error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.joinChannel).mockRejectedValue(new Error('is_archived'));
+
+      await program.parseAsync(['node', 'slack-cli', 'join', '-c', 'archived-channel']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle method_not_supported_for_channel_type error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.joinChannel).mockRejectedValue(
+        new Error('method_not_supported_for_channel_type')
+      );
+
+      await program.parseAsync(['node', 'slack-cli', 'join', '-c', 'dm-channel']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/commands/leave.test.ts
+++ b/tests/commands/leave.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setupLeaveCommand } from '../../src/commands/leave';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { setupMockConsole, createTestProgram, restoreMocks } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('leave command', () => {
+  let program: any;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockReturnValue(mockConfigManager);
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockReturnValue(mockSlackClient);
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupLeaveCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('leave channel', () => {
+    it('should leave a channel', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.leaveChannel).mockResolvedValue();
+
+      await program.parseAsync(['node', 'slack-cli', 'leave', '-c', 'general']);
+
+      expect(mockSlackClient.leaveChannel).toHaveBeenCalledWith('general');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Left channel #general')
+      );
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.leaveChannel).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'leave',
+        '-c',
+        'general',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync(['node', 'slack-cli', 'leave', '-c', 'general']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle channel_not_found error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.leaveChannel).mockRejectedValue(new Error('channel_not_found'));
+
+      await program.parseAsync(['node', 'slack-cli', 'leave', '-c', 'nonexistent']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle cant_leave_general error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.leaveChannel).mockRejectedValue(
+        new Error('cant_leave_general')
+      );
+
+      await program.parseAsync(['node', 'slack-cli', 'leave', '-c', 'general']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle last_member error', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.leaveChannel).mockRejectedValue(new Error('last_member'));
+
+      await program.parseAsync(['node', 'slack-cli', 'leave', '-c', 'solo-channel']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/utils/slack-operations/channel-join-leave-operations.test.ts
+++ b/tests/utils/slack-operations/channel-join-leave-operations.test.ts
@@ -1,0 +1,138 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ChannelOperations } from '../../../src/utils/slack-operations/channel-operations';
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(() => ({
+    conversations: {
+      list: vi.fn(),
+      info: vi.fn(),
+      history: vi.fn(),
+      join: vi.fn(),
+      leave: vi.fn(),
+    },
+  })),
+  LogLevel: {
+    ERROR: 'error',
+  },
+}));
+
+vi.mock('p-limit', () => ({
+  default: () => (fn: any) => fn(),
+}));
+
+describe('ChannelOperations - join/leave', () => {
+  let channelOps: ChannelOperations;
+  let mockClient: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = {
+      conversations: {
+        list: vi.fn(),
+        info: vi.fn(),
+        history: vi.fn(),
+        join: vi.fn(),
+        leave: vi.fn(),
+      },
+    };
+    channelOps = new ChannelOperations('test-token');
+    (channelOps as any).client = mockClient;
+  });
+
+  describe('joinChannel', () => {
+    it('should join a channel with channel name resolution', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [{ id: 'C123', name: 'general' }],
+      });
+      mockClient.conversations.join.mockResolvedValue({
+        ok: true,
+        channel: { id: 'C123' },
+      });
+
+      await channelOps.joinChannel('general');
+
+      expect(mockClient.conversations.join).toHaveBeenCalledWith({
+        channel: 'C123',
+      });
+    });
+
+    it('should join a channel with channel ID directly', async () => {
+      mockClient.conversations.join.mockResolvedValue({
+        ok: true,
+        channel: { id: 'C1234567890' },
+      });
+
+      await channelOps.joinChannel('C1234567890');
+
+      expect(mockClient.conversations.join).toHaveBeenCalledWith({
+        channel: 'C1234567890',
+      });
+      // Should not call list when given a channel ID
+      expect(mockClient.conversations.list).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when channel is not found', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [],
+      });
+
+      await expect(channelOps.joinChannel('nonexistent')).rejects.toThrow();
+    });
+
+    it('should propagate API errors', async () => {
+      mockClient.conversations.join.mockRejectedValue(new Error('is_archived'));
+
+      await expect(channelOps.joinChannel('C1234567890')).rejects.toThrow('is_archived');
+    });
+  });
+
+  describe('leaveChannel', () => {
+    it('should leave a channel with channel name resolution', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [{ id: 'C456', name: 'random' }],
+      });
+      mockClient.conversations.leave.mockResolvedValue({
+        ok: true,
+      });
+
+      await channelOps.leaveChannel('random');
+
+      expect(mockClient.conversations.leave).toHaveBeenCalledWith({
+        channel: 'C456',
+      });
+    });
+
+    it('should leave a channel with channel ID directly', async () => {
+      mockClient.conversations.leave.mockResolvedValue({
+        ok: true,
+      });
+
+      await channelOps.leaveChannel('C1234567890');
+
+      expect(mockClient.conversations.leave).toHaveBeenCalledWith({
+        channel: 'C1234567890',
+      });
+      expect(mockClient.conversations.list).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when channel is not found', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [],
+      });
+
+      await expect(channelOps.leaveChannel('nonexistent')).rejects.toThrow();
+    });
+
+    it('should propagate cant_leave_general error', async () => {
+      mockClient.conversations.leave.mockRejectedValue(new Error('cant_leave_general'));
+
+      await expect(channelOps.leaveChannel('C1234567890')).rejects.toThrow('cant_leave_general');
+    });
+
+    it('should propagate last_member error', async () => {
+      mockClient.conversations.leave.mockRejectedValue(new Error('last_member'));
+
+      await expect(channelOps.leaveChannel('C1234567890')).rejects.toThrow('last_member');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `slack-cli join -c <channel>` command to join channels via `conversations.join` API
- Add `slack-cli leave -c <channel>` command to leave channels via `conversations.leave` API
- Both commands support channel name resolution and `--profile` option
- Includes comprehensive tests for commands and channel operations

## Test plan
- [x] Unit tests for `join` command (6 tests: join, profile, error handling for missing config / channel_not_found / is_archived / method_not_supported_for_channel_type)
- [x] Unit tests for `leave` command (6 tests: leave, profile, error handling for missing config / channel_not_found / cant_leave_general / last_member)
- [x] Unit tests for channel operations join/leave (9 tests: name resolution, direct ID, not found, API error propagation)
- [x] All 514 existing tests pass

Closes #108