### PR TITLE
perf: use users.conversations to optimize channel/unread discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/slack-operations/channel-operations.ts
+++ b/src/utils/slack-operations/channel-operations.ts
@@ -54,7 +54,9 @@ export class ChannelOperations extends BaseSlackClient {
   }
 
   async listUnreadChannels(): Promise<Channel[]> {
-    const channels = await this.fetchAllChannels();
+    // Use users.conversations instead of conversations.list to only fetch
+    // channels the current user is a member of, reducing API calls significantly
+    const channels = await this.fetchUserChannels();
     const channelsWithUnread: Channel[] = [];
 
     // Process channels one by one with delay to avoid rate limits
@@ -76,14 +78,32 @@ export class ChannelOperations extends BaseSlackClient {
     return channelsWithUnread;
   }
 
-  private async fetchAllChannels(): Promise<Channel[]> {
-    const response = await this.client.conversations.list({
-      types: 'public_channel,private_channel,im,mpim',
-      exclude_archived: true,
-      limit: 1000,
-    });
+  /**
+   * Fetch channels the current user is a member of using users.conversations API.
+   * This is more efficient than conversations.list for unread discovery since
+   * unread messages only exist in channels the user has joined.
+   * Supports pagination via next_cursor.
+   */
+  async fetchUserChannels(): Promise<Channel[]> {
+    const channels: Channel[] = [];
+    let cursor: string | undefined;
 
-    return response.channels as Channel[];
+    do {
+      const response = await this.client.users.conversations({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: 200,
+        cursor,
+      });
+
+      if (response.channels) {
+        channels.push(...(response.channels as Channel[]));
+      }
+
+      cursor = response.response_metadata?.next_cursor;
+    } while (cursor);
+
+    return channels;
   }
 
   private async getChannelUnreadInfo(channel: Channel): Promise<Channel | null> {

--- a/tests/utils/slack-operations/channel-operations.test.ts
+++ b/tests/utils/slack-operations/channel-operations.test.ts
@@ -8,6 +8,9 @@ vi.mock('@slack/web-api', () => ({
       info: vi.fn(),
       history: vi.fn(),
     },
+    users: {
+      conversations: vi.fn(),
+    },
   })),
   LogLevel: {
     ERROR: 'error',
@@ -30,6 +33,9 @@ describe('ChannelOperations', () => {
         info: vi.fn(),
         history: vi.fn(),
       },
+      users: {
+        conversations: vi.fn(),
+      },
     };
     // Create instance with mocked token
     channelOps = new ChannelOperations('test-token');
@@ -37,14 +43,157 @@ describe('ChannelOperations', () => {
     (channelOps as any).client = mockClient;
   });
 
-  describe('listUnreadChannels', () => {
-    it('should detect unread messages when last_read is present', async () => {
-      // Mock conversations.list response
-      mockClient.conversations.list.mockResolvedValue({
+  describe('fetchUserChannels', () => {
+    it('should use users.conversations API to fetch user channels', async () => {
+      mockClient.users.conversations.mockResolvedValue({
         channels: [
           { id: 'C123', name: 'general' },
           { id: 'C456', name: 'random' },
         ],
+        response_metadata: { next_cursor: '' },
+      });
+
+      const result = await channelOps.fetchUserChannels();
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toMatchObject({ id: 'C123', name: 'general' });
+      expect(result[1]).toMatchObject({ id: 'C456', name: 'random' });
+      expect(mockClient.users.conversations).toHaveBeenCalledWith({
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: 200,
+        cursor: undefined,
+      });
+    });
+
+    it('should handle pagination with next_cursor', async () => {
+      mockClient.users.conversations
+        .mockResolvedValueOnce({
+          channels: [
+            { id: 'C001', name: 'channel-1' },
+            { id: 'C002', name: 'channel-2' },
+          ],
+          response_metadata: { next_cursor: 'cursor_page2' },
+        })
+        .mockResolvedValueOnce({
+          channels: [
+            { id: 'C003', name: 'channel-3' },
+          ],
+          response_metadata: { next_cursor: '' },
+        });
+
+      const result = await channelOps.fetchUserChannels();
+
+      expect(result).toHaveLength(3);
+      expect(result[0].id).toBe('C001');
+      expect(result[1].id).toBe('C002');
+      expect(result[2].id).toBe('C003');
+      expect(mockClient.users.conversations).toHaveBeenCalledTimes(2);
+      expect(mockClient.users.conversations).toHaveBeenNthCalledWith(2, {
+        types: 'public_channel,private_channel,im,mpim',
+        exclude_archived: true,
+        limit: 200,
+        cursor: 'cursor_page2',
+      });
+    });
+
+    it('should handle multiple pages of pagination', async () => {
+      mockClient.users.conversations
+        .mockResolvedValueOnce({
+          channels: [{ id: 'C001', name: 'ch1' }],
+          response_metadata: { next_cursor: 'cursor2' },
+        })
+        .mockResolvedValueOnce({
+          channels: [{ id: 'C002', name: 'ch2' }],
+          response_metadata: { next_cursor: 'cursor3' },
+        })
+        .mockResolvedValueOnce({
+          channels: [{ id: 'C003', name: 'ch3' }],
+          response_metadata: { next_cursor: '' },
+        });
+
+      const result = await channelOps.fetchUserChannels();
+
+      expect(result).toHaveLength(3);
+      expect(mockClient.users.conversations).toHaveBeenCalledTimes(3);
+    });
+
+    it('should return empty array when user has no channels', async () => {
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [],
+        response_metadata: { next_cursor: '' },
+      });
+
+      const result = await channelOps.fetchUserChannels();
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should include all channel types (public, private, im, mpim)', async () => {
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [
+          { id: 'C001', name: 'public-ch', is_channel: true },
+          { id: 'G001', name: 'private-ch', is_group: true },
+          { id: 'D001', name: 'dm', is_im: true },
+          { id: 'G002', name: 'group-dm', is_mpim: true },
+        ],
+        response_metadata: { next_cursor: '' },
+      });
+
+      const result = await channelOps.fetchUserChannels();
+
+      expect(result).toHaveLength(4);
+      expect(mockClient.users.conversations).toHaveBeenCalledWith(
+        expect.objectContaining({
+          types: 'public_channel,private_channel,im,mpim',
+        })
+      );
+    });
+
+    it('should handle undefined channels in response', async () => {
+      mockClient.users.conversations.mockResolvedValue({
+        response_metadata: { next_cursor: '' },
+      });
+
+      const result = await channelOps.fetchUserChannels();
+
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('listUnreadChannels', () => {
+    it('should use users.conversations instead of conversations.list', async () => {
+      // Mock users.conversations response (used by fetchUserChannels)
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [
+          { id: 'C123', name: 'general' },
+        ],
+        response_metadata: { next_cursor: '' },
+      });
+
+      mockClient.conversations.info.mockResolvedValue({
+        channel: { id: 'C123', name: 'general', last_read: '1234567890.000100' },
+      });
+
+      mockClient.conversations.history.mockResolvedValue({
+        messages: [],
+      });
+
+      await channelOps.listUnreadChannels();
+
+      // Should use users.conversations, NOT conversations.list
+      expect(mockClient.users.conversations).toHaveBeenCalled();
+      expect(mockClient.conversations.list).not.toHaveBeenCalled();
+    });
+
+    it('should detect unread messages when last_read is present', async () => {
+      // Mock users.conversations response
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [
+          { id: 'C123', name: 'general' },
+          { id: 'C456', name: 'random' },
+        ],
+        response_metadata: { next_cursor: '' },
       });
 
       // Mock conversations.info responses
@@ -95,9 +244,10 @@ describe('ChannelOperations', () => {
     });
 
     it('should count all messages as unread when last_read is not present', async () => {
-      // Mock conversations.list response
-      mockClient.conversations.list.mockResolvedValue({
+      // Mock users.conversations response
+      mockClient.users.conversations.mockResolvedValue({
         channels: [{ id: 'C789', name: 'no-read-channel' }],
+        response_metadata: { next_cursor: '' },
       });
 
       // Mock conversations.info response - no last_read
@@ -137,8 +287,9 @@ describe('ChannelOperations', () => {
     });
 
     it('should skip channels with no messages', async () => {
-      mockClient.conversations.list.mockResolvedValue({
+      mockClient.users.conversations.mockResolvedValue({
         channels: [{ id: 'C999', name: 'empty-channel' }],
+        response_metadata: { next_cursor: '' },
       });
 
       mockClient.conversations.info.mockResolvedValue({
@@ -160,8 +311,9 @@ describe('ChannelOperations', () => {
     });
 
     it('should skip channels with all messages read', async () => {
-      mockClient.conversations.list.mockResolvedValue({
+      mockClient.users.conversations.mockResolvedValue({
         channels: [{ id: 'C111', name: 'all-read' }],
+        response_metadata: { next_cursor: '' },
       });
 
       mockClient.conversations.info.mockResolvedValue({
@@ -176,7 +328,7 @@ describe('ChannelOperations', () => {
       mockClient.conversations.history.mockResolvedValueOnce({
         messages: [{ ts: '1234567890.000100' }],
       });
-      
+
       // Second call to get messages after last_read (should be empty)
       mockClient.conversations.history.mockResolvedValueOnce({
         messages: [],
@@ -188,11 +340,12 @@ describe('ChannelOperations', () => {
     });
 
     it('should handle API errors gracefully', async () => {
-      mockClient.conversations.list.mockResolvedValue({
+      mockClient.users.conversations.mockResolvedValue({
         channels: [
           { id: 'C222', name: 'error-channel' },
           { id: 'C333', name: 'good-channel' },
         ],
+        response_metadata: { next_cursor: '' },
       });
 
       // First channel throws error
@@ -223,12 +376,13 @@ describe('ChannelOperations', () => {
 
     it('should handle rate limiting with delay', async () => {
       const delaySpy = vi.spyOn(channelOps as any, 'delay');
-      
-      mockClient.conversations.list.mockResolvedValue({
+
+      mockClient.users.conversations.mockResolvedValue({
         channels: [
           { id: 'C444', name: 'channel1' },
           { id: 'C555', name: 'channel2' },
         ],
+        response_metadata: { next_cursor: '' },
       });
 
       mockClient.conversations.info.mockResolvedValue({
@@ -243,6 +397,54 @@ describe('ChannelOperations', () => {
 
       // Verify delay was called between API calls
       expect(delaySpy).toHaveBeenCalledWith(100);
+    });
+  });
+
+  describe('listChannels', () => {
+    it('should still use conversations.list for channel listing', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [
+          { id: 'C123', name: 'general' },
+          { id: 'C456', name: 'random' },
+        ],
+      });
+
+      const result = await channelOps.listChannels({
+        types: 'public_channel',
+        exclude_archived: true,
+        limit: 100,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(mockClient.conversations.list).toHaveBeenCalledWith({
+        types: 'public_channel',
+        exclude_archived: true,
+        limit: 100,
+        cursor: undefined,
+      });
+      // Should NOT use users.conversations
+      expect(mockClient.users.conversations).not.toHaveBeenCalled();
+    });
+
+    it('should handle pagination for conversations.list', async () => {
+      mockClient.conversations.list
+        .mockResolvedValueOnce({
+          channels: [{ id: 'C001', name: 'ch1' }],
+          response_metadata: { next_cursor: 'cursor2' },
+        })
+        .mockResolvedValueOnce({
+          channels: [{ id: 'C002', name: 'ch2' }],
+          response_metadata: { next_cursor: '' },
+        });
+
+      const result = await channelOps.listChannels({
+        types: 'public_channel',
+        exclude_archived: true,
+        limit: 100,
+      });
+
+      expect(result).toHaveLength(2);
+      expect(mockClient.conversations.list).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace `conversations.list` with `users.conversations` API in the unread scanning flow (`listUnreadChannels`)
- Add `fetchUserChannels()` method with full pagination support via `next_cursor`
- Keep `conversations.list` for the `channels` command which needs to list all workspace channels
- Bump version to 0.18.2

## Motivation
`conversations.list` returns ALL channels in a workspace (potentially thousands), but unread messages only exist in channels the user has joined. `users.conversations` returns only channels the authenticated user is a member of, which is typically a much smaller set. This reduces:
- The initial channel list size
- The number of subsequent `conversations.info` and `conversations.history` API calls per channel
- Overall rate limit pressure

## Test plan
- [x] New tests for `fetchUserChannels()` (pagination, filtering, empty responses, all channel types)
- [x] Test verifying `listUnreadChannels` uses `users.conversations` instead of `conversations.list`
- [x] Test verifying `listChannels` still uses `conversations.list` (no regression for channels command)
- [x] Updated all existing `listUnreadChannels` tests to mock the new API
- [x] Full test suite passes (579 tests, 0 failures)

Closes #106