### PR TITLE
ci: skip Claude Code Review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -41,4 +42,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary
- Add a job-level condition to Claude Code Review workflow
- Skip claude-review when the PR comes from a fork (head.repo.fork == true)

## Why
- Current workflow fails on fork PRs because OIDC env vars are unavailable in that context
- This causes noisy red CI unrelated to code quality

## Scope
- Only affects the Claude Code Review workflow
- Internal PRs (non-fork) continue to run as before