### PR TITLE
ci: add allowedTools to claude-implement and claude-code-review workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,4 +41,4 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           allowed_bots: 'dependabot[bot]'
-          claude_args: '--allowedTools Read,Glob,Grep,Bash,WebFetch,WebSearch'
+          claude_args: '--allowedTools Read,Glob,Grep,Bash(gh:*),Bash(git:*)'

--- a/.github/workflows/claude-implement.yml
+++ b/.github/workflows/claude-implement.yml
@@ -44,7 +44,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: '--allowedTools Read,Write,Edit,Glob,Grep,Bash,WebFetch,WebSearch'
+          claude_args: '--allowedTools Read,Write,Edit,Glob,Grep,Bash(npm:*),Bash(npx:*),Bash(git:*),Bash(gh:*),Bash(mkdir:*),Bash(ls:*),WebFetch,WebSearch'
           prompt: |
             Issue #${{ github.event.issue.number }} の実装を行ってください。
 


### PR DESCRIPTION
## 概要

CI環境の `claude-code-action` に `--allowedTools` と `allowed_bots` を追加し、Claude Codeが正常にツールを使用できるようにする。

## 背景

### claude-implement.yml
Issue #181 で `approved` ラベル付与によりワークフローがトリガーされたが、Claude Codeが9ターン中8回パーミッション拒否され、PR作成に至らなかった。

原因: ローカルの `.claude/settings.local.json` は `.gitignore` に含まれておりCI環境に存在しないため、許可されたツールがゼロの状態でClaude Codeが実行された。

### claude-code-review.yml
2つの問題:
1. `allowedTools` 未設定 → Claude Codeがツール使用を拒否され続け、15分のタイムアウトでキャンセル
2. `allowed_bots` 未設定 → dependabot PRで `Workflow initiated by non-human actor` エラー

## 変更内容

- `claude-implement.yml`: `claude_args: '--allowedTools Read,Write,Edit,Glob,Grep,Bash,WebFetch,WebSearch'` を追加
- `claude-code-review.yml`: `claude_args: '--allowedTools Read,Glob,Grep,Bash,WebFetch,WebSearch'` と `allowed_bots: 'dependabot[bot]'` を追加