### PR TITLE
ci: allow claude[bot] in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,5 +40,5 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          allowed_bots: 'dependabot[bot]'
+          allowed_bots: 'dependabot[bot],claude[bot]'
           claude_args: '--allowedTools Read,Glob,Grep,Bash(gh:*),Bash(git:*)'


### PR DESCRIPTION
## Summary
- claude[bot]が作成したPRでClaude Code Reviewワークフローが失敗していた問題を修正
- `allowed_bots`に`claude[bot]`を追加

## 原因
`claude-implement.yml`でClaude(Bot)がPRを作成すると、actorが`claude[bot]`になる。
`claude-code-review.yml`の`allowed_bots`に`dependabot[bot]`しか含まれていなかったため、Bot起因のPRがブロックされていた。

## 変更内容
`allowed_bots: 'dependabot[bot]'` → `allowed_bots: 'dependabot[bot],claude[bot]'`