### PR TITLE
Claude Code Reviewがレビューを投稿しない問題のデバッグ

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,4 +59,5 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           allowed_bots: 'dependabot[bot],claude[bot]'
+          show_full_output: true
           claude_args: '--allowedTools Read,Glob,Grep,Bash(gh:*),Bash(git:*)'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.9",
+  "version": "0.20.10",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
# 背景

- Claude Code Review ワークフローは正常に完了（success）するが、PRにレビューコメントが一切投稿されない
- 直近のPR (#196, #195, #194, #193) すべてでレビューが付いていない
- `pull-requests: write` 権限は修正済み（f6b9e35）だが、それでも動作しない

# 概要

- `show_full_output: true` を有効化し、Claude Code が内部で何を実行しているか可視化する
- これにより、code-review プラグインがレビュー分析後に投稿に失敗しているのか、そもそもレビューを生成していないのかを判別できる

```mermaid
flowchart TD
    A[PR作成/更新] --> B[claude-code-review workflow 実行]
    B --> C[Claude Code 5ターン実行]
    C --> D{レビュー投稿?}
    D -->|現状: No| E[原因不明 - ログが非表示]
    D -->|期待: Yes| F[PRにレビューコメント]
    
    style E fill:#f66,color:#fff
    style F fill:#6f6,color:#fff
```

# 次のステップ

1. このPRのCIログで `show_full_output` の出力を確認
2. 原因に応じて `claude_args` の `--allowedTools` 制限を見直す