### PR TITLE
fix: keep claude review visible on PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -59,5 +59,9 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           allowed_bots: 'dependabot[bot],claude[bot]'
+          # Keep a single visible PR comment updated so successful reviews are still observable
+          # even when there are no new inline findings.
+          use_sticky_comment: true
+          display_report: true
           show_full_output: true
           claude_args: '--allowedTools Read,Glob,Grep,Bash(gh:*),Bash(git:*)'


### PR DESCRIPTION
## Summary
- enable sticky PR comments for Claude Code Review so successful runs remain visible even without new inline findings
- enable action report output for easier run inspection
- keep the existing review plugin flow unchanged

## Notes
- this PR changes the review workflow itself, so the Claude Code Review job is expected to skip on this PR by design
- the behavior should be verified on the next normal code PR after merge
