### PR TITLE
Dependabotの安全な自動リリースを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -13,6 +15,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,8 +49,12 @@ jobs:
         if: steps.changed-files.outputs.workflow_changes == 'true'
         run: echo "Workflow changes detected. Skipping Claude Code Review to avoid GitHub App workflow validation failure."
 
+      - name: Skip Claude Code Review for Dependabot PRs
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+        run: echo "Dependabot PR detected. Skipping Claude Code Review because Dependabot risk is handled by the dedicated auto-release workflow."
+
       - name: Run Claude Code Review
-        if: steps.changed-files.outputs.workflow_changes != 'true'
+        if: steps.changed-files.outputs.workflow_changes != 'true' && github.event.pull_request.user.login != 'dependabot[bot]'
         id: claude-review
         uses: anthropics/claude-code-action@88c168b39e7e64da0286d812b6e9fbebb6708185 # v1.0.82
         with:

--- a/.github/workflows/dependabot-auto-release.yml
+++ b/.github/workflows/dependabot-auto-release.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: dependabot-auto-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: read
@@ -37,6 +41,7 @@ jobs:
         uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: ${{ steps.app-token.outputs.token }}
+          skip-commit-verification: true
 
       - name: List changed files
         id: changed-files
@@ -81,6 +86,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REPOSITORY: ${{ github.repository }}
         run: |
           gh api --method GET "repos/$REPOSITORY/contents/package.json" -f ref="$HEAD_REF" > /tmp/package-response.json
@@ -90,12 +96,7 @@ jobs:
 
           BASE_VERSION=$(git show "$BASE_SHA:package.json" | node -e "const fs = require('node:fs'); console.log(JSON.parse(fs.readFileSync(0, 'utf8')).version);")
           CURRENT_VERSION=$(node -e "const fs = require('node:fs'); console.log(JSON.parse(fs.readFileSync('/tmp/package.json', 'utf8')).version);")
-
-          if [ "$CURRENT_VERSION" != "$BASE_VERSION" ]; then
-            echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Version already bumped: $BASE_VERSION -> $CURRENT_VERSION"
-            exit 0
-          fi
+          export BASE_VERSION
 
           node - <<'NODE'
           const fs = require('node:fs');
@@ -112,43 +113,86 @@ jobs:
           const packageJsonRaw = fs.readFileSync('/tmp/package.json', 'utf8');
           const packageJson = JSON.parse(packageJsonRaw);
           const currentVersion = packageJson.version;
-          const nextVersion = bumpPatch(currentVersion);
-          const nextPackageJsonRaw = packageJsonRaw.replace(
-            `"version": "${currentVersion}"`,
-            `"version": "${nextVersion}"`
-          );
-          fs.writeFileSync('/tmp/package.json', nextPackageJsonRaw);
+          const baseVersion = process.env.BASE_VERSION;
 
           const packageLock = JSON.parse(fs.readFileSync('/tmp/package-lock.json', 'utf8'));
-          packageLock.version = nextVersion;
-          if (packageLock.packages && packageLock.packages['']) {
-            packageLock.packages[''].version = nextVersion;
+          const lockVersion = packageLock.version;
+          const lockRootVersion = packageLock.packages?.['']?.version;
+
+          let nextVersion = currentVersion;
+          let nextPackageJsonRaw = packageJsonRaw;
+
+          if (currentVersion === baseVersion) {
+            nextVersion = bumpPatch(currentVersion);
+            nextPackageJsonRaw = packageJsonRaw.replace(
+              `"version": "${currentVersion}"`,
+              `"version": "${nextVersion}"`
+            );
+          } else if (lockVersion === currentVersion && lockRootVersion === currentVersion) {
+            fs.writeFileSync('/tmp/version-change-needed', 'false');
+            fs.writeFileSync('/tmp/next-version', currentVersion);
+            process.exit(0);
           }
+
+          packageLock.version = nextVersion;
+          packageLock.packages ??= {};
+          packageLock.packages[''] ??= {};
+          packageLock.packages[''].version = nextVersion;
+          fs.writeFileSync('/tmp/package.json', nextPackageJsonRaw);
           fs.writeFileSync('/tmp/package-lock.json', `${JSON.stringify(packageLock, null, 2)}\n`);
+          fs.writeFileSync('/tmp/version-change-needed', 'true');
           fs.writeFileSync('/tmp/next-version', nextVersion);
           NODE
 
-          PACKAGE_SHA=$(jq -r ".sha" /tmp/package-response.json)
-          PACKAGE_LOCK_SHA=$(jq -r ".sha" /tmp/package-lock-response.json)
-          PACKAGE_CONTENT=$(base64 -w0 /tmp/package.json)
-          PACKAGE_LOCK_CONTENT=$(base64 -w0 /tmp/package-lock.json)
+          if [ "$(cat /tmp/version-change-needed)" != "true" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version already bumped and lockfile is in sync: $CURRENT_VERSION"
+            exit 0
+          fi
+
           NEXT_VERSION=$(cat /tmp/next-version)
+          TREE_SHA=$(gh api "repos/$REPOSITORY/git/commits/$HEAD_SHA" --jq ".tree.sha")
+          PACKAGE_BLOB_SHA=$(
+            gh api \
+              --method POST \
+              "repos/$REPOSITORY/git/blobs" \
+              -f content="$(base64 -w0 /tmp/package.json)" \
+              -f encoding="base64" \
+              --jq ".sha"
+          )
+          PACKAGE_LOCK_BLOB_SHA=$(
+            gh api \
+              --method POST \
+              "repos/$REPOSITORY/git/blobs" \
+              -f content="$(base64 -w0 /tmp/package-lock.json)" \
+              -f encoding="base64" \
+              --jq ".sha"
+          )
 
-          gh api \
-            --method PUT \
-            "repos/$REPOSITORY/contents/package.json" \
-            -f branch="$HEAD_REF" \
-            -f content="$PACKAGE_CONTENT" \
-            -f message="chore: bump version to $NEXT_VERSION" \
-            -f sha="$PACKAGE_SHA"
-
-          gh api \
-            --method PUT \
-            "repos/$REPOSITORY/contents/package-lock.json" \
-            -f branch="$HEAD_REF" \
-            -f content="$PACKAGE_LOCK_CONTENT" \
-            -f message="chore: sync lockfile version to $NEXT_VERSION" \
-            -f sha="$PACKAGE_LOCK_SHA"
+          NEXT_TREE_SHA=$(
+            jq -n \
+              --arg base_tree "$TREE_SHA" \
+              --arg package_blob "$PACKAGE_BLOB_SHA" \
+              --arg lock_blob "$PACKAGE_LOCK_BLOB_SHA" \
+              '{
+                base_tree: $base_tree,
+                tree: [
+                  { path: "package.json", mode: "100644", type: "blob", sha: $package_blob },
+                  { path: "package-lock.json", mode: "100644", type: "blob", sha: $lock_blob }
+                ]
+              }' |
+              gh api --method POST "repos/$REPOSITORY/git/trees" --input - --jq ".sha"
+          )
+          NEXT_COMMIT_SHA=$(
+            jq -n \
+              --arg message "chore: bump version to $NEXT_VERSION" \
+              --arg tree "$NEXT_TREE_SHA" \
+              --arg parent "$HEAD_SHA" \
+              '{ message: $message, tree: $tree, parents: [$parent] }' |
+              gh api --method POST "repos/$REPOSITORY/git/commits" --input - --jq ".sha"
+          )
+          jq -n --arg sha "$NEXT_COMMIT_SHA" '{ sha: $sha, force: false }' |
+            gh api --method PATCH "repos/$REPOSITORY/git/refs/heads/$HEAD_REF" --input -
 
           echo "changed=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/dependabot-auto-release.yml
+++ b/.github/workflows/dependabot-auto-release.yml
@@ -1,0 +1,178 @@
+name: Dependabot Auto Release
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  risk-assessment:
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
+      - name: Checkout base branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+
+      - name: List changed files
+        id: changed-files
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          {
+            echo "files<<EOF"
+            gh pr diff "$PR_URL" --name-only
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Evaluate Dependabot risk
+        id: risk
+        continue-on-error: true
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.files }}
+          DEPENDENCY_NAMES: ${{ steps.metadata.outputs.dependency-names }}
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+          MAINTAINER_CHANGES: ${{ steps.metadata.outputs.maintainer-changes }}
+          PACKAGE_ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
+          UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+        run: node scripts/dependabot-risk.cjs
+
+      - name: Mark unsafe PR
+        if: steps.risk.outputs.status != 'safe'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          RISK_REASON: ${{ steps.risk.outputs.reason }}
+        run: |
+          gh label create dependabot-needs-review --color D93F0B --description "Dependabot update requires human review" || true
+          gh pr edit "$PR_URL" --add-label dependabot-needs-review
+          gh pr comment "$PR_URL" --body "Dependabot auto-release stopped: $RISK_REASON"
+          echo "::error::$RISK_REASON"
+          exit 1
+
+      - name: Bump package version
+        id: bump-version
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          gh api --method GET "repos/$REPOSITORY/contents/package.json" -f ref="$HEAD_REF" > /tmp/package-response.json
+          gh api --method GET "repos/$REPOSITORY/contents/package-lock.json" -f ref="$HEAD_REF" > /tmp/package-lock-response.json
+          jq -r ".content" /tmp/package-response.json | base64 -d > /tmp/package.json
+          jq -r ".content" /tmp/package-lock-response.json | base64 -d > /tmp/package-lock.json
+
+          BASE_VERSION=$(git show "$BASE_SHA:package.json" | node -e "const fs = require('node:fs'); console.log(JSON.parse(fs.readFileSync(0, 'utf8')).version);")
+          CURRENT_VERSION=$(node -e "const fs = require('node:fs'); console.log(JSON.parse(fs.readFileSync('/tmp/package.json', 'utf8')).version);")
+
+          if [ "$CURRENT_VERSION" != "$BASE_VERSION" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version already bumped: $BASE_VERSION -> $CURRENT_VERSION"
+            exit 0
+          fi
+
+          node - <<'NODE'
+          const fs = require('node:fs');
+
+          const bumpPatch = (version) => {
+            const parts = version.split('.').map(Number);
+            if (parts.length !== 3 || parts.some((part) => !Number.isInteger(part))) {
+              throw new Error(`Unsupported package version: ${version}`);
+            }
+            parts[2] += 1;
+            return parts.join('.');
+          };
+
+          const packageJsonRaw = fs.readFileSync('/tmp/package.json', 'utf8');
+          const packageJson = JSON.parse(packageJsonRaw);
+          const currentVersion = packageJson.version;
+          const nextVersion = bumpPatch(currentVersion);
+          const nextPackageJsonRaw = packageJsonRaw.replace(
+            `"version": "${currentVersion}"`,
+            `"version": "${nextVersion}"`
+          );
+          fs.writeFileSync('/tmp/package.json', nextPackageJsonRaw);
+
+          const packageLock = JSON.parse(fs.readFileSync('/tmp/package-lock.json', 'utf8'));
+          packageLock.version = nextVersion;
+          if (packageLock.packages && packageLock.packages['']) {
+            packageLock.packages[''].version = nextVersion;
+          }
+          fs.writeFileSync('/tmp/package-lock.json', `${JSON.stringify(packageLock, null, 2)}\n`);
+          fs.writeFileSync('/tmp/next-version', nextVersion);
+          NODE
+
+          PACKAGE_SHA=$(jq -r ".sha" /tmp/package-response.json)
+          PACKAGE_LOCK_SHA=$(jq -r ".sha" /tmp/package-lock-response.json)
+          PACKAGE_CONTENT=$(base64 -w0 /tmp/package.json)
+          PACKAGE_LOCK_CONTENT=$(base64 -w0 /tmp/package-lock.json)
+          NEXT_VERSION=$(cat /tmp/next-version)
+
+          gh api \
+            --method PUT \
+            "repos/$REPOSITORY/contents/package.json" \
+            -f branch="$HEAD_REF" \
+            -f content="$PACKAGE_CONTENT" \
+            -f message="chore: bump version to $NEXT_VERSION" \
+            -f sha="$PACKAGE_SHA"
+
+          gh api \
+            --method PUT \
+            "repos/$REPOSITORY/contents/package-lock.json" \
+            -f branch="$HEAD_REF" \
+            -f content="$PACKAGE_LOCK_CONTENT" \
+            -f message="chore: sync lockfile version to $NEXT_VERSION" \
+            -f sha="$PACKAGE_LOCK_SHA"
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Mark safe PR
+        if: steps.bump-version.outputs.changed != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          RISK_REASON: ${{ steps.risk.outputs.reason }}
+        run: |
+          gh label create dependabot-safe --color 0E8A16 --description "Dependabot update passed auto-release risk checks" || true
+          gh pr edit "$PR_URL" --add-label dependabot-safe --remove-label dependabot-needs-review || true
+          gh pr comment "$PR_URL" --body "Dependabot auto-release approved: $RISK_REASON"
+
+      - name: Approve PR
+        if: steps.bump-version.outputs.changed != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr review "$PR_URL" --approve --body "Approved by Dependabot auto-release risk assessment."
+
+      - name: Enable auto-merge
+        if: steps.bump-version.outputs.changed != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --auto --squash

--- a/biome.json
+++ b/biome.json
@@ -186,6 +186,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["scripts/**/*.cjs"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noCommonJs": "off"
+          }
+        }
+      }
     }
   ],
   "assist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.21",
+  "version": "0.20.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.20.21",
+      "version": "0.20.22",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.21",
+  "version": "0.20.22",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/dependabot-risk.cjs
+++ b/scripts/dependabot-risk.cjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+
+const fs = require('node:fs');
+
+const SAFE_UPDATE_TYPES = new Set(['version-update:semver-patch', 'version-update:semver-minor']);
+
+const SUPPORTED_ECOSYSTEMS = new Set(['npm', 'npm_and_yarn', 'github_actions']);
+
+const PACKAGE_VERSION_FILES = new Set(['package.json', 'package-lock.json']);
+
+function normalizeEcosystem(ecosystem) {
+  return String(ecosystem || '').replaceAll('-', '_');
+}
+
+function normalizeMetadata(metadata = {}) {
+  return {
+    dependencyNames: metadata.dependencyNames || metadata['dependency-names'] || '',
+    dependencyType: metadata.dependencyType || metadata['dependency-type'] || '',
+    ecosystem: normalizeEcosystem(
+      metadata.ecosystem || metadata.packageEcosystem || metadata['package-ecosystem']
+    ),
+    maintainerChanges: String(
+      metadata.maintainerChanges || metadata['maintainer-changes'] || 'false'
+    ),
+    updateType: metadata.updateType || metadata['update-type'] || '',
+  };
+}
+
+function isTruthy(value) {
+  return ['1', 'true', 'yes'].includes(String(value).toLowerCase());
+}
+
+function isAllowedNpmFile(file) {
+  return PACKAGE_VERSION_FILES.has(file);
+}
+
+function isAllowedGitHubActionsFile(file) {
+  return (
+    file.startsWith('.github/workflows/') ||
+    file.startsWith('.github/actions/') ||
+    file === 'action.yml' ||
+    file === 'action.yaml' ||
+    PACKAGE_VERSION_FILES.has(file)
+  );
+}
+
+function findUnexpectedFiles(ecosystem, changedFiles) {
+  const isAllowedFile =
+    ecosystem === 'github_actions' ? isAllowedGitHubActionsFile : isAllowedNpmFile;
+  return changedFiles.filter((file) => !isAllowedFile(file));
+}
+
+function evaluateDependabotRisk(input) {
+  const metadata = normalizeMetadata(input.metadata);
+  const changedFiles = [...new Set(input.changedFiles || [])].filter(Boolean).sort();
+
+  if (!metadata.dependencyNames || !metadata.ecosystem || !metadata.updateType) {
+    return {
+      status: 'unsafe',
+      reason: 'Dependabot metadata is incomplete.',
+    };
+  }
+
+  if (!SUPPORTED_ECOSYSTEMS.has(metadata.ecosystem)) {
+    return {
+      status: 'unsafe',
+      reason: `Unsupported ecosystem: ${metadata.ecosystem}.`,
+    };
+  }
+
+  if (isTruthy(metadata.maintainerChanges)) {
+    return {
+      status: 'unsafe',
+      reason: 'PR contains maintainer changes.',
+    };
+  }
+
+  if (!SAFE_UPDATE_TYPES.has(metadata.updateType)) {
+    return {
+      status: 'unsafe',
+      reason: `Update type is not allowed for auto release: ${metadata.updateType}. Major and unknown updates require human review.`,
+    };
+  }
+
+  if (changedFiles.length === 0) {
+    return {
+      status: 'unsafe',
+      reason: 'No changed files were provided for risk evaluation.',
+    };
+  }
+
+  const unexpectedFiles = findUnexpectedFiles(metadata.ecosystem, changedFiles);
+  if (unexpectedFiles.length > 0) {
+    return {
+      status: 'unsafe',
+      reason: `Unexpected files changed: ${unexpectedFiles.join(', ')}.`,
+    };
+  }
+
+  return {
+    status: 'safe',
+    reason: `${metadata.updateType} ${metadata.ecosystem} update for ${metadata.dependencyNames}.`,
+  };
+}
+
+function parseChangedFiles(value) {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // Fall back to newline or comma separated input.
+  }
+
+  return value
+    .split(/\r?\n|,/)
+    .map((file) => file.trim())
+    .filter(Boolean);
+}
+
+function appendGithubOutput(result) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    return;
+  }
+
+  fs.appendFileSync(outputPath, `status=${result.status}\n`);
+  fs.appendFileSync(outputPath, `reason=${result.reason}\n`);
+}
+
+function runCli() {
+  const result = evaluateDependabotRisk({
+    changedFiles: parseChangedFiles(process.env.CHANGED_FILES),
+    metadata: {
+      dependencyNames: process.env.DEPENDENCY_NAMES,
+      dependencyType: process.env.DEPENDENCY_TYPE,
+      ecosystem: process.env.PACKAGE_ECOSYSTEM,
+      maintainerChanges: process.env.MAINTAINER_CHANGES,
+      updateType: process.env.UPDATE_TYPE,
+    },
+  });
+
+  appendGithubOutput(result);
+  console.log(`${result.status}: ${result.reason}`);
+
+  if (result.status !== 'safe') {
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  runCli();
+}
+
+module.exports = {
+  evaluateDependabotRisk,
+  normalizeMetadata,
+  parseChangedFiles,
+};

--- a/tests/dependabot-risk.test.ts
+++ b/tests/dependabot-risk.test.ts
@@ -1,0 +1,109 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { evaluateDependabotRisk } =
+  require('../scripts/dependabot-risk.cjs') as typeof import('../scripts/dependabot-risk.cjs');
+
+const safeMetadata = {
+  dependencyNames: '@slack/web-api',
+  dependencyType: 'direct:production',
+  ecosystem: 'npm',
+  maintainerChanges: 'false',
+  updateType: 'version-update:semver-patch',
+};
+
+describe('dependabot risk evaluator', () => {
+  it('marks npm patch updates as safe', () => {
+    const result = evaluateDependabotRisk({
+      changedFiles: ['package.json', 'package-lock.json'],
+      metadata: safeMetadata,
+    });
+
+    expect(result.status).toBe('safe');
+  });
+
+  it('marks GitHub Actions minor updates as safe', () => {
+    const result = evaluateDependabotRisk({
+      changedFiles: ['.github/workflows/ci.yml'],
+      metadata: {
+        ...safeMetadata,
+        dependencyNames: 'actions/checkout',
+        ecosystem: 'github_actions',
+        updateType: 'version-update:semver-minor',
+      },
+    });
+
+    expect(result.status).toBe('safe');
+  });
+
+  it('marks major updates as unsafe', () => {
+    const result = evaluateDependabotRisk({
+      changedFiles: ['package.json', 'package-lock.json'],
+      metadata: {
+        ...safeMetadata,
+        updateType: 'version-update:semver-major',
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'unsafe',
+      reason: expect.stringContaining('major'),
+    });
+  });
+
+  it('marks missing metadata as unsafe', () => {
+    const result = evaluateDependabotRisk({
+      changedFiles: ['package.json', 'package-lock.json'],
+      metadata: {
+        ...safeMetadata,
+        updateType: '',
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'unsafe',
+      reason: expect.stringContaining('metadata'),
+    });
+  });
+
+  it('marks maintainer changes as unsafe', () => {
+    const result = evaluateDependabotRisk({
+      changedFiles: ['package.json', 'package-lock.json'],
+      metadata: {
+        ...safeMetadata,
+        maintainerChanges: 'true',
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: 'unsafe',
+      reason: expect.stringContaining('maintainer'),
+    });
+  });
+
+  it('marks unexpected file changes as unsafe', () => {
+    const result = evaluateDependabotRisk({
+      changedFiles: ['package.json', 'package-lock.json', 'src/index.ts'],
+      metadata: safeMetadata,
+    });
+
+    expect(result).toMatchObject({
+      status: 'unsafe',
+      reason: expect.stringContaining('Unexpected files'),
+    });
+  });
+
+  it('allows package version files after workflow version bump', () => {
+    const result = evaluateDependabotRisk({
+      changedFiles: ['.github/workflows/ci.yml', 'package.json', 'package-lock.json'],
+      metadata: {
+        ...safeMetadata,
+        dependencyNames: 'actions/setup-node',
+        ecosystem: 'github_actions',
+      },
+    });
+
+    expect(result.status).toBe('safe');
+  });
+});


### PR DESCRIPTION
# 背景

- Dependabot PRがレビュー待ちで滞留しており、低リスクな依存更新は自動で取り込んでリリースまで進めたい。
- 新バージョン公開直後は取り込まず、Dependabot native cooldownで7日待ってからPR化する。

# 概要

- `.github/dependabot.yml` のnpm / GitHub Actions更新に `cooldown.default-days: 7` を追加。
- Dependabot PR専用のリスク判定workflowを追加し、patch/minorかつ想定ファイルのみの変更をsafe扱いにする。
- safeなPRはGitHub App tokenでpackage versionをpatch bumpし、CI成功後にapproveとauto-mergeを有効化する。
- version bumpは `package.json` と `package-lock.json` をGit tree/commit APIで同一コミットとして更新し、途中状態や競合を避ける。
- major、metadata欠落、maintainer changes、想定外ファイル変更はCIで落として人間レビューに回す。
- Dependabot PRではClaude Code Reviewをスキップし、専用risk workflowに判定を集約する。
- このPR自体もリリース対象のCI変更なので、`package.json` / `package-lock.json` を `0.20.22` にpatch bumpしている。

# 確認方法

- `npm test -- tests/dependabot-risk.test.ts`
- `npm run check`
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `actrun lint .github/workflows/dependabot-auto-release.yml`
- `actrun lint .github/workflows/claude-code-review.yml`
- `actrun workflow run .github/workflows/dependabot-auto-release.yml --dry-run --workspace-mode local`

# レビュー指摘への対応

- `dependabot/fetch-metadata` に `skip-commit-verification: true` を追加し、workflowがversion bump commitを追加した後の再実行でもmetadataを取得できるようにした。
- PR番号単位の `concurrency` を追加し、同一Dependabot PRでの並行実行を直列化した。
- version bump済み判定時もlockfileのversion一致を確認し、不整合があれば同期コミットを作成するようにした。
- `package.json` と `package-lock.json` はGit tree/commit APIで同一コミットにまとめて更新するようにした。

# 補足

- `GH_APP_ID` と `GH_APP_PRIVATE_KEY` をActions secretsに設定する必要があります。
- GitHub Appには `contents: write`、`pull_requests: write`、`issues: write` が必要です。
- security updatesはDependabot cooldownの対象外なので、即時起票のままです。

