### PR TITLE
AGENTS.mdをCLAUDE.mdへのリンクにする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.22",
+  "version": "0.20.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.20.22",
+      "version": "0.20.23",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.22",
+  "version": "0.20.23",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
# 背景

- Codex向けの `AGENTS.md` と既存の `CLAUDE.md` が同じ内容になっていたため、二重管理を避けたい。

# 概要

- `AGENTS.md` を `CLAUDE.md` へのシンボリックリンクとして追加。
- PR単位のリリース要件に合わせて `package.json` / `package-lock.json` を `0.20.23` にpatch bump。

# 確認方法

- `npm run check`
- `npm run build`
- `npm test`
- `ls -l AGENTS.md CLAUDE.md`

