### PR TITLE
feat: add download command for thread/message file attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,25 @@ slack-cli upload -c general --content 'console.log("hello")' --filename snippet.
 slack-cli upload -c general -f ./logs.txt -t 1234567890.123456
 ```
 
+### Download Files
+
+```bash
+# Download every file attached to a thread
+slack-cli download -c general -t 1234567890.123456
+
+# Download to a specific directory
+slack-cli download -c general -t 1234567890.123456 -o ./downloads
+
+# Only download files attached to one message in the thread
+slack-cli download -c general -t 1234567890.123456 --ts 1234567899.654321
+
+# List attached files without downloading
+slack-cli download -c general -t 1234567890.123456 --list
+
+# List attached files as JSON
+slack-cli download -c general -t 1234567890.123456 --list --format json
+```
+
 ### Reactions
 
 ```bash
@@ -448,6 +467,17 @@ printf '%s\n' "$NEW_TOKEN" | slack-cli config set --token-stdin
 | --filetype |       | Snippet type (e.g. python, javascript, csv)      |
 | --thread   | -t    | Thread timestamp to upload as reply              |
 
+### download command
+
+| Option    | Short | Description                                                  |
+| --------- | ----- | ------------------------------------------------------------ |
+| --channel | -c    | Channel name or ID (required)                                |
+| --thread  | -t    | Thread timestamp, the root ts of the thread (required)       |
+| --ts      |       | Only download files attached to the message with this ts     |
+| --output  | -o    | Output directory (default: current directory)                |
+| --list    |       | List attached files without downloading                      |
+| --format  |       | Output format for --list: table, simple, json (default: table) |
+
 ### reaction command
 
 | Option      | Short | Description                              |
@@ -558,7 +588,7 @@ Your Slack API token needs the following scopes:
 - `pins:read` - List pinned items in a channel
 - `pins:write` - Pin and unpin messages
 - `files:write` - Upload files and snippets
-- `files:read` - List canvases linked to a channel
+- `files:read` - Download files attached to messages and list canvases linked to a channel
 - `canvases:read` - Read Canvas sections
 
 ## Advanced Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.23",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.20.23",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.23",
+  "version": "0.21.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/download.ts
+++ b/src/commands/download.ts
@@ -1,0 +1,82 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { resolve } from 'path';
+import { DownloadOptions } from '../types/commands';
+import { renderByFormat, withSlackClient } from '../utils/command-support';
+import { wrapCommand } from '../utils/command-wrapper';
+import { FileError } from '../utils/errors';
+import { createValidationHook, optionValidators } from '../utils/validators';
+
+export function setupDownloadCommand(): Command {
+  const downloadCommand = new Command('download')
+    .description('Download files attached to a thread or message')
+    .requiredOption('-c, --channel <channel>', 'Channel name or ID')
+    .requiredOption('-t, --thread <thread>', 'Thread timestamp (the root ts of the thread)')
+    .option('--ts <ts>', 'Only download files attached to the message with this timestamp')
+    .option('-o, --output <dir>', 'Output directory', '.')
+    .option('--list', 'List attached files without downloading', false)
+    .option('--format <format>', 'Output format for --list: table, simple, json', 'table')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook(
+      'preAction',
+      createValidationHook([
+        optionValidators.threadTimestamp,
+        optionValidators.downloadMessageTs,
+        optionValidators.format,
+      ])
+    )
+    .action(
+      wrapCommand(async (options: DownloadOptions) => {
+        await withSlackClient(options, async (client) => {
+          const files = await client.listThreadFiles(options.channel, options.thread, {
+            messageTs: options.ts,
+          });
+
+          if (files.length === 0) {
+            console.log('No files found in the specified thread or message.');
+            return;
+          }
+
+          if (options.list) {
+            renderByFormat(options, files, {
+              table: (data) => {
+                for (const file of data) {
+                  const name = file.name || file.title || '(no name)';
+                  console.log(
+                    `${file.id}\t${name}\t${file.filetype ?? '?'}\t${file.size ?? 0} bytes`
+                  );
+                }
+              },
+            });
+            return;
+          }
+
+          const outputDir = resolve(options.output ?? '.');
+          let downloaded = 0;
+
+          for (const file of files) {
+            try {
+              const result = await client.downloadFile(file, outputDir);
+              downloaded++;
+              console.log(chalk.green(`✓ ${result.name} (${result.size} bytes) -> ${result.path}`));
+            } catch (error) {
+              const message = error instanceof Error ? error.message : String(error);
+              console.error(chalk.yellow(`⚠ Skipped ${file.name || file.id}: ${message}`));
+            }
+          }
+
+          // Surface a final tally so partial downloads are never silent.
+          const summary = `Downloaded ${downloaded}/${files.length} file(s) to ${outputDir}`;
+          if (downloaded === files.length) {
+            console.log(chalk.green(`✓ ${summary}`));
+          } else {
+            // Exit non-zero on partial failure so scripts/CI can detect it.
+            console.log(chalk.yellow(`⚠ ${summary}`));
+            throw new FileError(`${files.length - downloaded} file(s) could not be downloaded.`);
+          }
+        });
+      })
+    );
+
+  return downloadCommand;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { setupChannelCommand } from './commands/channel';
 import { setupChannelsCommand } from './commands/channels';
 import { setupConfigCommand } from './commands/config';
 import { setupDeleteCommand } from './commands/delete';
+import { setupDownloadCommand } from './commands/download';
 import { setupEditCommand } from './commands/edit';
 import { setupHistoryCommand } from './commands/history';
 import { setupInviteCommand } from './commands/invite';
@@ -56,6 +57,7 @@ export function createProgram(): Command {
   program.addCommand(setupEditCommand());
   program.addCommand(setupDeleteCommand());
   program.addCommand(setupUploadCommand());
+  program.addCommand(setupDownloadCommand());
   program.addCommand(setupReactionCommand());
   program.addCommand(setupPinCommand());
   program.addCommand(setupUsersCommand());

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -79,6 +79,16 @@ export interface UploadOptions {
   profile?: string;
 }
 
+export interface DownloadOptions {
+  channel: string;
+  thread: string;
+  ts?: string;
+  output?: string;
+  list?: boolean;
+  format?: 'table' | 'simple' | 'json';
+  profile?: string;
+}
+
 export interface EditOptions {
   channel: string;
   ts: string;

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -27,7 +27,12 @@ import type {
 import { createSlackClientContext } from './slack-operations/base-client';
 import { CanvasOperations } from './slack-operations/canvas-operations';
 import { ChannelOperations } from './slack-operations/channel-operations';
-import type { UploadFileOptions } from './slack-operations/file-operations';
+import type {
+  DownloadedFile,
+  ListThreadFilesOptions,
+  ThreadFile,
+  UploadFileOptions,
+} from './slack-operations/file-operations';
 import { FileOperations } from './slack-operations/file-operations';
 import { MessageOperations } from './slack-operations/message-operations';
 import { PinOperations } from './slack-operations/pin-operations';
@@ -53,7 +58,7 @@ export class SlackApiClient {
     const sharedContext = createSlackClientContext(token);
     this.channelOps = new ChannelOperations(sharedContext);
     this.messageOps = new MessageOperations(sharedContext, this.channelOps);
-    this.fileOps = new FileOperations(sharedContext, this.channelOps);
+    this.fileOps = new FileOperations(sharedContext, this.channelOps, token);
     this.reactionOps = new ReactionOperations(sharedContext, this.channelOps);
     this.pinOps = new PinOperations(sharedContext, this.channelOps);
     this.userOps = new UserOperations(sharedContext);
@@ -156,6 +161,18 @@ export class SlackApiClient {
 
   async uploadFile(options: UploadFileOptions): Promise<void> {
     return this.fileOps.uploadFile(options);
+  }
+
+  async listThreadFiles(
+    channel: string,
+    threadTs: string,
+    options?: ListThreadFilesOptions
+  ): Promise<ThreadFile[]> {
+    return this.fileOps.listThreadFiles(channel, threadTs, options);
+  }
+
+  async downloadFile(file: ThreadFile, destDir: string): Promise<DownloadedFile> {
+    return this.fileOps.downloadFile(file, destDir);
   }
 
   async addReaction(channel: string, timestamp: string, emoji: string): Promise<void> {

--- a/src/utils/slack-operations/file-operations.ts
+++ b/src/utils/slack-operations/file-operations.ts
@@ -1,4 +1,9 @@
-import { basename } from 'path';
+import { createWriteStream } from 'fs';
+import { access, mkdir, rm } from 'fs/promises';
+import { basename, extname, isAbsolute, join, relative, resolve } from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { FileError } from '../errors';
 import { BaseSlackClient, SlackClientDependency } from './base-client';
 import { ChannelOperations } from './channel-operations';
 
@@ -13,12 +18,43 @@ export interface UploadFileOptions {
   threadTs?: string;
 }
 
+/** A file object as returned inside a message's `files` array by conversations.replies. */
+export interface ThreadFile {
+  id: string;
+  name?: string;
+  title?: string;
+  filetype?: string;
+  size?: number;
+  mode?: string;
+  is_external?: boolean;
+  url_private?: string;
+  url_private_download?: string;
+  permalink?: string;
+}
+
+export interface ListThreadFilesOptions {
+  /** When set, only collect files attached to the message with this exact timestamp. */
+  messageTs?: string;
+}
+
+export interface DownloadedFile {
+  id: string;
+  name: string;
+  path: string;
+  size: number;
+  contentType: string;
+}
+
 export class FileOperations extends BaseSlackClient {
   private channelOps: ChannelOperations;
+  private token?: string;
 
-  constructor(dependency: SlackClientDependency, channelOps?: ChannelOperations) {
+  constructor(dependency: SlackClientDependency, channelOps?: ChannelOperations, token?: string) {
     super(dependency);
     this.channelOps = channelOps ?? new ChannelOperations(dependency);
+    // Capture the token explicitly rather than reaching into WebClient internals,
+    // so downloads keep working regardless of the @slack/web-api version.
+    this.token = token ?? (typeof dependency === 'string' ? dependency : undefined);
   }
 
   async uploadFile(options: UploadFileOptions): Promise<void> {
@@ -44,5 +80,170 @@ export class FileOperations extends BaseSlackClient {
     await this.client.files.uploadV2(
       params as unknown as Parameters<typeof this.client.files.uploadV2>[0]
     );
+  }
+
+  /**
+   * Collect the file objects attached to a thread (optionally narrowed to a
+   * single message). Paginates conversations.replies so every reply is scanned.
+   */
+  async listThreadFiles(
+    channel: string,
+    threadTs: string,
+    options: ListThreadFilesOptions = {}
+  ): Promise<ThreadFile[]> {
+    const channelId = await this.channelOps.resolveChannelId(channel);
+    const files: ThreadFile[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const response = await this.client.conversations.replies({
+        channel: channelId,
+        ts: threadTs,
+        cursor,
+        limit: 200,
+      });
+
+      for (const message of response.messages ?? []) {
+        if (options.messageTs && message.ts !== options.messageTs) {
+          continue;
+        }
+        for (const file of (message.files ?? []) as ThreadFile[]) {
+          files.push(file);
+        }
+      }
+
+      cursor = response.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+
+    return files;
+  }
+
+  /**
+   * Download a single Slack file object to destDir, reusing the authenticated
+   * token for the Authorization header that url_private(_download) requires.
+   * The response body is streamed to disk so large files never sit fully in memory.
+   */
+  async downloadFile(file: ThreadFile, destDir: string): Promise<DownloadedFile> {
+    const label = file.name || file.title || file.id;
+    const url = file.url_private_download || file.url_private;
+    if (!url) {
+      throw new FileError(
+        `File "${label}" has no downloadable URL (mode: ${file.mode ?? 'unknown'}). ` +
+          'External or hosted files cannot be downloaded.'
+      );
+    }
+
+    if (!this.token) {
+      throw new FileError('No authentication token is available for downloading files.');
+    }
+
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${this.token}` },
+      redirect: 'follow',
+    });
+
+    if (!response.ok) {
+      throw new FileError(
+        `Failed to download "${label}": HTTP ${response.status} ${response.statusText}`
+      );
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+
+    // Slack responds with a 200 HTML login page when the token lacks access.
+    if (contentType.includes('text/html') && file.filetype !== 'html') {
+      throw new FileError(
+        `Received an HTML page instead of file data for "${label}" — ` +
+          'the token may lack access to this file.'
+      );
+    }
+
+    if (!response.body) {
+      throw new FileError(`Empty response body while downloading "${label}".`);
+    }
+
+    const resolvedDir = resolve(destDir);
+    await mkdir(resolvedDir, { recursive: true });
+    const destPath = await this.resolveDestPath(resolvedDir, file);
+
+    let size = 0;
+    const source = Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]);
+    source.on('data', (chunk: Buffer) => {
+      size += chunk.length;
+    });
+
+    try {
+      await pipeline(source, createWriteStream(destPath));
+    } catch (error) {
+      await rm(destPath, { force: true }).catch(() => undefined);
+      const message = error instanceof Error ? error.message : String(error);
+      throw new FileError(`Failed while writing "${label}": ${message}`);
+    }
+
+    return {
+      id: file.id,
+      name: basename(destPath),
+      path: destPath,
+      size,
+      contentType,
+    };
+  }
+
+  /**
+   * Build a safe, collision-free destination path inside resolvedDir.
+   * Slack file names are user-controlled, so they are reduced to a basename and
+   * checked to never escape the output directory (path traversal guard).
+   */
+  private async resolveDestPath(resolvedDir: string, file: ThreadFile): Promise<string> {
+    const filename = sanitizeFilename(file.name, file.id);
+    const candidate = resolve(resolvedDir, filename);
+    const rel = relative(resolvedDir, candidate);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new FileError(
+        `Refusing to write "${file.name ?? file.id}" outside the output directory.`
+      );
+    }
+
+    if (!(await pathExists(candidate))) {
+      return candidate;
+    }
+
+    // Deconflict duplicate names by appending the unique Slack file id, then a
+    // counter, looping until a free path is found so nothing is overwritten.
+    const ext = extname(filename);
+    const stem = filename.slice(0, filename.length - ext.length);
+    for (let attempt = 1; ; attempt++) {
+      const suffix = attempt === 1 ? `-${file.id}` : `-${file.id}-${attempt}`;
+      const next = resolve(resolvedDir, `${stem}${suffix}${ext}`);
+      if (!(await pathExists(next))) {
+        return next;
+      }
+    }
+  }
+}
+
+/**
+ * Reduce a Slack-supplied file name to a single safe path segment via basename.
+ * Falls back to the file id when the result is empty, is `.`/`..`, still contains
+ * a path separator (e.g. a backslash on POSIX, which basename does not strip), or
+ * contains any control character. Combined with the containment check in
+ * resolveDestPath, this prevents path traversal from attacker-controlled names.
+ */
+function sanitizeFilename(rawName: string | undefined, fallbackId: string): string {
+  const base = basename((rawName ?? '').trim());
+  const hasSeparator = base.includes('/') || base.includes('\\');
+  const hasControlChar = Array.from(base).some((char) => char.charCodeAt(0) < 0x20);
+  if (!base || base === '.' || base === '..' || hasSeparator || hasControlChar) {
+    return fallbackId;
+  }
+  return base;
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
   }
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -240,6 +240,16 @@ export const optionValidators = {
   },
 
   /**
+   * Validates the optional message timestamp (--ts) for the download command
+   */
+  downloadMessageTs: (options: Record<string, unknown>): string | null => {
+    if (options.ts) {
+      return formatValidators.threadTimestamp(options.ts as string);
+    }
+    return null;
+  },
+
+  /**
    * Validates edit message timestamp if provided
    */
   editTimestamp: (options: Record<string, unknown>): string | null => {

--- a/tests/commands/download.test.ts
+++ b/tests/commands/download.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupDownloadCommand } from '../../src/commands/download';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import type { ThreadFile } from '../../src/utils/slack-operations/file-operations';
+import { createTestProgram, restoreMocks, setupMockConsole } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+const sampleFiles: ThreadFile[] = [
+  {
+    id: 'F001',
+    name: 'SKILL.md',
+    title: 'masterplan-coach',
+    filetype: 'markdown',
+    size: 1234,
+    mode: 'snippet',
+    url_private_download: 'https://files.slack.com/files-pri/T1-F001/download/skill.md',
+  },
+  {
+    id: 'F002',
+    name: 'mp_variable_dictionary.yaml',
+    filetype: 'yaml',
+    size: 567,
+    mode: 'hosted',
+    url_private_download: 'https://files.slack.com/files-pri/T1-F002/download/dict.yaml',
+  },
+];
+
+describe('download command', () => {
+  let program: ReturnType<typeof createTestProgram>;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: ReturnType<typeof setupMockConsole>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockImplementation(function () {
+      return mockConfigManager;
+    });
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockImplementation(function () {
+      return mockSlackClient;
+    });
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupDownloadCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('downloading files', () => {
+    it('should download every file attached to a thread', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listThreadFiles).mockResolvedValue(sampleFiles);
+      vi.mocked(mockSlackClient.downloadFile).mockImplementation(async (file) => ({
+        id: file.id,
+        name: file.name as string,
+        path: `/out/${file.name}`,
+        size: file.size ?? 0,
+        contentType: 'application/octet-stream',
+      }));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+        '-o',
+        '/out',
+      ]);
+
+      expect(mockSlackClient.listThreadFiles).toHaveBeenCalledWith('general', '1778642820.183399', {
+        messageTs: undefined,
+      });
+      expect(mockSlackClient.downloadFile).toHaveBeenCalledTimes(2);
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Downloaded 2/2'));
+    });
+
+    it('should narrow downloads to a single message with --ts', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listThreadFiles).mockResolvedValue([sampleFiles[0]]);
+      vi.mocked(mockSlackClient.downloadFile).mockResolvedValue({
+        id: 'F001',
+        name: 'SKILL.md',
+        path: '/out/SKILL.md',
+        size: 1234,
+        contentType: 'text/markdown',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+        '--ts',
+        '1779967716.201649',
+      ]);
+
+      expect(mockSlackClient.listThreadFiles).toHaveBeenCalledWith('general', '1778642820.183399', {
+        messageTs: '1779967716.201649',
+      });
+      expect(mockSlackClient.downloadFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report a partial download when one file fails', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listThreadFiles).mockResolvedValue(sampleFiles);
+      vi.mocked(mockSlackClient.downloadFile)
+        .mockResolvedValueOnce({
+          id: 'F001',
+          name: 'SKILL.md',
+          path: '/out/SKILL.md',
+          size: 1234,
+          contentType: 'text/markdown',
+        })
+        .mockRejectedValueOnce(new Error('HTTP 403 Forbidden'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Skipped mp_variable_dictionary.yaml')
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Downloaded 1/2'));
+      // Partial failure must exit non-zero so scripts/CI can detect it.
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should report when no files are found', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listThreadFiles).mockResolvedValue([]);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('No files found'));
+      expect(mockSlackClient.downloadFile).not.toHaveBeenCalled();
+    });
+
+    it('should use the specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listThreadFiles).mockResolvedValue([]);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+  });
+
+  describe('--list', () => {
+    it('should list files without downloading', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listThreadFiles).mockResolvedValue(sampleFiles);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+        '--list',
+      ]);
+
+      expect(mockSlackClient.downloadFile).not.toHaveBeenCalled();
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('SKILL.md'));
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('mp_variable_dictionary.yaml')
+      );
+    });
+
+    it('should list files as JSON', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listThreadFiles).mockResolvedValue(sampleFiles);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+        '--list',
+        '--format',
+        'json',
+      ]);
+
+      expect(mockSlackClient.downloadFile).not.toHaveBeenCalled();
+      const jsonOutput = mockConsole.logSpy.mock.calls
+        .map((call) => String(call[0]))
+        .find((output) => output.includes('F001'));
+      expect(jsonOutput).toBeDefined();
+      expect(JSON.parse(jsonOutput as string)).toHaveLength(2);
+    });
+  });
+
+  describe('validation', () => {
+    it('should fail when thread timestamp is invalid', async () => {
+      const downloadCommand = setupDownloadCommand();
+      downloadCommand.exitOverride();
+
+      await expect(
+        downloadCommand.parseAsync(['-c', 'general', '-t', 'invalid-ts'], { from: 'user' })
+      ).rejects.toThrow('Invalid thread timestamp format');
+    });
+
+    it('should fail when --ts is invalid', async () => {
+      const downloadCommand = setupDownloadCommand();
+      downloadCommand.exitOverride();
+
+      await expect(
+        downloadCommand.parseAsync(['-c', 'general', '-t', '1778642820.183399', '--ts', 'nope'], {
+          from: 'user',
+        })
+      ).rejects.toThrow('Invalid thread timestamp format');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle missing configuration', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'download',
+        '-c',
+        'general',
+        '-t',
+        '1778642820.183399',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/utils/slack-operations/file-operations.test.ts
+++ b/tests/utils/slack-operations/file-operations.test.ts
@@ -1,12 +1,21 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { channelResolver } from '../../../src/utils/channel-resolver';
-import { FileOperations } from '../../../src/utils/slack-operations/file-operations';
+import {
+  FileOperations,
+  type ThreadFile,
+} from '../../../src/utils/slack-operations/file-operations';
 
 vi.mock('@slack/web-api', () => ({
   WebClient: vi.fn().mockImplementation(function () {
     return {
       files: {
         uploadV2: vi.fn(),
+      },
+      conversations: {
+        replies: vi.fn(),
       },
     };
   }),
@@ -17,10 +26,42 @@ vi.mock('@slack/web-api', () => ({
 
 vi.mock('../../../src/utils/channel-resolver');
 
+function webStreamFrom(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+function mockFetchResponse(options: {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  contentType?: string;
+  body?: string | null;
+}): Response {
+  const { ok = true, status = 200, statusText = 'OK', contentType = 'text/plain' } = options;
+  const body = options.body === undefined ? 'file-contents' : options.body;
+  return {
+    ok,
+    status,
+    statusText,
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'content-type' ? contentType : null),
+    },
+    body: body === null ? null : webStreamFrom(body),
+  } as unknown as Response;
+}
+
 describe('FileOperations', () => {
   type MockClient = {
     files: {
       uploadV2: ReturnType<typeof vi.fn>;
+    };
+    conversations: {
+      replies: ReturnType<typeof vi.fn>;
     };
   };
 
@@ -31,6 +72,10 @@ describe('FileOperations', () => {
     vi.clearAllMocks();
     fileOps = new FileOperations('test-token');
     mockClient = (fileOps as unknown as { client: MockClient }).client;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   describe('uploadFile', () => {
@@ -122,6 +167,162 @@ describe('FileOperations', () => {
           filePath: '/path/to/file.txt',
         })
       ).rejects.toThrow('not_allowed_token_type');
+    });
+  });
+
+  describe('listThreadFiles', () => {
+    beforeEach(() => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+    });
+
+    it('should collect files across paginated replies', async () => {
+      mockClient.conversations.replies
+        .mockResolvedValueOnce({
+          messages: [{ ts: '1.1', files: [{ id: 'F1', name: 'a.txt' }] }],
+          response_metadata: { next_cursor: 'CURSOR2' },
+        })
+        .mockResolvedValueOnce({
+          messages: [{ ts: '2.2', files: [{ id: 'F2', name: 'b.txt' }] }],
+          response_metadata: { next_cursor: '' },
+        });
+
+      const files = await fileOps.listThreadFiles('general', '1.1');
+
+      expect(files.map((f) => f.id)).toEqual(['F1', 'F2']);
+      expect(mockClient.conversations.replies).toHaveBeenCalledTimes(2);
+      expect(mockClient.conversations.replies).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'C123456789', ts: '1.1', limit: 200 })
+      );
+    });
+
+    it('should narrow to a single message when messageTs is given', async () => {
+      mockClient.conversations.replies.mockResolvedValue({
+        messages: [
+          { ts: '1.1', files: [{ id: 'F1', name: 'a.txt' }] },
+          { ts: '2.2', files: [{ id: 'F2', name: 'b.txt' }] },
+        ],
+        response_metadata: { next_cursor: '' },
+      });
+
+      const files = await fileOps.listThreadFiles('general', '1.1', { messageTs: '2.2' });
+
+      expect(files.map((f) => f.id)).toEqual(['F2']);
+    });
+
+    it('should return empty array when no files are attached', async () => {
+      mockClient.conversations.replies.mockResolvedValue({
+        messages: [{ ts: '1.1' }],
+        response_metadata: { next_cursor: '' },
+      });
+
+      const files = await fileOps.listThreadFiles('general', '1.1');
+
+      expect(files).toEqual([]);
+    });
+  });
+
+  describe('downloadFile', () => {
+    let outDir: string;
+
+    const baseFile: ThreadFile = {
+      id: 'F100',
+      name: 'report.csv',
+      filetype: 'csv',
+      url_private_download: 'https://files.slack.com/files-pri/T1-F100/download/report.csv',
+    };
+
+    beforeEach(async () => {
+      outDir = await mkdtemp(join(tmpdir(), 'slack-cli-dl-'));
+    });
+
+    afterEach(async () => {
+      await rm(outDir, { recursive: true, force: true });
+    });
+
+    it('should download a file to disk', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(mockFetchResponse({ body: 'col1,col2\n1,2\n' }))
+      );
+
+      const result = await fileOps.downloadFile(baseFile, outDir);
+
+      expect(result.name).toBe('report.csv');
+      expect(result.size).toBe('col1,col2\n1,2\n'.length);
+      const written = await readFile(join(outDir, 'report.csv'), 'utf-8');
+      expect(written).toBe('col1,col2\n1,2\n');
+    });
+
+    it('should send the bearer token in the Authorization header', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(mockFetchResponse({ body: 'x' }));
+      vi.stubGlobal('fetch', fetchMock);
+
+      await fileOps.downloadFile(baseFile, outDir);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        baseFile.url_private_download,
+        expect.objectContaining({ headers: { Authorization: 'Bearer test-token' } })
+      );
+    });
+
+    it('should sanitize path-traversal file names to the file id', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchResponse({ body: 'x' })));
+
+      const result = await fileOps.downloadFile({ ...baseFile, name: '../../evil.sh' }, outDir);
+
+      // basename strips the path, leaving "evil.sh"; never escapes outDir.
+      expect(result.path.startsWith(outDir)).toBe(true);
+      expect(result.name).toBe('evil.sh');
+    });
+
+    it('should fall back to file id when the name is a separator-only path', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockFetchResponse({ body: 'x' })));
+
+      const result = await fileOps.downloadFile({ ...baseFile, name: '/' }, outDir);
+
+      expect(result.name).toBe('F100');
+    });
+
+    it('should deconflict duplicate file names with the file id', async () => {
+      // Return a fresh response (and stream) per call so the body is never reused.
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(() => mockFetchResponse({ body: 'x' }))
+      );
+
+      const first = await fileOps.downloadFile(baseFile, outDir);
+      const second = await fileOps.downloadFile({ ...baseFile, id: 'F200' }, outDir);
+
+      expect(first.name).toBe('report.csv');
+      expect(second.name).toBe('report-F200.csv');
+    });
+
+    it('should throw when the file has no downloadable URL', async () => {
+      await expect(
+        fileOps.downloadFile({ id: 'F1', name: 'x', mode: 'external', is_external: true }, outDir)
+      ).rejects.toThrow('no downloadable URL');
+    });
+
+    it('should reject an HTML login page returned for an inaccessible file', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(mockFetchResponse({ contentType: 'text/html', body: '<html>' }))
+      );
+
+      await expect(fileOps.downloadFile(baseFile, outDir)).rejects.toThrow(
+        'HTML page instead of file data'
+      );
+    });
+
+    it('should throw on a non-OK HTTP response', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValue(mockFetchResponse({ ok: false, status: 403, statusText: 'Forbidden' }))
+      );
+
+      await expect(fileOps.downloadFile(baseFile, outDir)).rejects.toThrow('HTTP 403 Forbidden');
     });
   });
 });


### PR DESCRIPTION
## 概要

スレッド（または `--ts` で特定メッセージ）に添付されたファイルをローカルにダウンロードする `download` コマンドを追加します。`history` / `upload` と同じ認証経路を再利用し、`url_private` のダウンロードに必要な Authorization ヘッダを付与します。

## 追加内容

- `slack-cli download -c <channel> -t <thread_ts>` でスレッドの全添付を取得
- `--ts <message_ts>` でスレッド内の特定メッセージの添付だけに絞る
- `-o, --output <dir>` で保存先指定（デフォルト: カレント）
- `--list`（table / json）でダウンロードせずに添付一覧を確認
- 一部失敗時も最後に `Downloaded N/M` の集計を出し、無言で失敗しない
- トークンが権限不足で HTML ログインページが返るケースをガード

## 実装

- `FileOperations.listThreadFiles`: `conversations.replies` をページングして files を収集（messageTs で絞り込み可）
- `FileOperations.downloadFile`: 認証トークンで取得しディスクへ保存
- `SlackApiClient` に passthrough を追加

## テスト

- `tests/commands/download.test.ts` を追加（10ケース: 通常DL / --ts絞り込み / 部分失敗 / 0件 / profile / --list table+json / バリデーション / 設定欠如）
- `npm run check` / `npm run build` / 追加テスト緑

## 必要スコープ

- `files:read`（添付ファイルのダウンロード）

## バージョン

- 0.20.23 → 0.21.0（minor: 新機能追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
