### PR TITLE
Slack ファイルダウンロードコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,19 @@ slack-cli upload -c general --content 'console.log("hello")' --filename snippet.
 slack-cli upload -c general -f ./logs.txt -t 1234567890.123456
 ```
 
+### Download Files
+
+```bash
+# Download the first file attached to a Slack message URL
+slack-cli file download --url "https://example.slack.com/archives/C123/p1780530261218279?thread_ts=1780527015.228619" --dir ./downloads
+
+# Download by Slack file ID
+slack-cli file download --id F012ABCDEF --output ./image.png
+
+# Download a file from a message timestamp
+slack-cli file download -c C123 -t 1780530261.218279 --thread 1780527015.228619 --index 1
+```
+
 ### Reactions
 
 ```bash
@@ -448,6 +461,19 @@ printf '%s\n' "$NEW_TOKEN" | slack-cli config set --token-stdin
 | --filetype |       | Snippet type (e.g. python, javascript, csv)      |
 | --thread   | -t    | Thread timestamp to upload as reply              |
 
+### file download command
+
+| Option      | Short | Description                                      |
+| ----------- | ----- | ------------------------------------------------ |
+| --id        |       | Slack file ID                                    |
+| --url       |       | Slack message permalink containing the file      |
+| --channel   | -c    | Channel name or ID                               |
+| --timestamp | -t    | Message timestamp containing the file            |
+| --thread    |       | Thread timestamp when downloading from a reply   |
+| --index     |       | 1-based file index for messages with many files  |
+| --output    | -o    | Output file path                                 |
+| --dir       | -d    | Output directory                                 |
+
 ### reaction command
 
 | Option      | Short | Description                              |
@@ -558,7 +584,7 @@ Your Slack API token needs the following scopes:
 - `pins:read` - List pinned items in a channel
 - `pins:write` - Pin and unpin messages
 - `files:write` - Upload files and snippets
-- `files:read` - List canvases linked to a channel
+- `files:read` - Download Slack files and list canvases linked to a channel
 - `canvases:read` - Read Canvas sections
 
 ## Advanced Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.23",
+  "version": "0.20.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.20.23",
+      "version": "0.20.24",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.23",
+  "version": "0.20.24",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/file.ts
+++ b/src/commands/file.ts
@@ -1,0 +1,140 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import { FileDownloadOptions } from '../types/commands';
+import { createSlackClient } from '../utils/client-factory';
+import { wrapCommand } from '../utils/command-wrapper';
+import { FileError } from '../utils/errors';
+import { parseProfile } from '../utils/option-parsers';
+
+interface ParsedSlackMessageUrl {
+  channel: string;
+  messageTs: string;
+  threadTs?: string;
+}
+
+export function setupFileCommand(): Command {
+  const fileCommand = new Command('file').description('Manage Slack files');
+
+  fileCommand
+    .command('download')
+    .description('Download a file attached to a Slack message')
+    .option('--id <fileId>', 'Slack file ID (for example F012ABCDEF)')
+    .option('--url <url>', 'Slack message permalink containing the file')
+    .option('-c, --channel <channel>', 'Channel name or ID')
+    .option('-t, --timestamp <timestamp>', 'Message timestamp containing the file')
+    .option('--thread <thread>', 'Thread timestamp when the message is a thread reply')
+    .option('--index <index>', '1-based file index when the message has multiple files', '1')
+    .option('-o, --output <path>', 'Output file path')
+    .option('-d, --dir <directory>', 'Output directory', '.')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .action(
+      wrapCommand(async (options: FileDownloadOptions) => {
+        const source = resolveDownloadSource(options);
+        const fileIndex = parseFileIndex(options.index);
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+
+        const result = await client.downloadFile({
+          fileId: source.fileId,
+          channel: source.channel,
+          messageTs: source.messageTs,
+          threadTs: source.threadTs,
+          fileIndex,
+          outputPath: options.output,
+          outputDir: options.output ? undefined : options.dir,
+        });
+
+        const name = result.file.name || result.file.title || result.file.id || 'Slack file';
+        console.log(chalk.green(`✓ Downloaded ${name} to ${result.path} (${result.bytes} bytes)`));
+      })
+    );
+
+  return fileCommand;
+}
+
+function resolveDownloadSource(options: FileDownloadOptions): {
+  fileId?: string;
+  channel?: string;
+  messageTs?: string;
+  threadTs?: string;
+} {
+  if (options.output && options.dir && options.dir !== '.') {
+    throw new FileError('Cannot use both --output and --dir');
+  }
+
+  const hasMessageSource = Boolean(options.channel || options.timestamp || options.thread);
+  const sourceCount = [Boolean(options.id), Boolean(options.url), hasMessageSource].filter(
+    Boolean
+  ).length;
+
+  if (sourceCount !== 1) {
+    throw new FileError('Specify exactly one source: --id, --url, or --channel with --timestamp');
+  }
+
+  if (options.id) {
+    return { fileId: options.id };
+  }
+
+  if (options.url) {
+    const parsed = parseSlackMessageUrl(options.url);
+    return {
+      channel: parsed.channel,
+      messageTs: parsed.messageTs,
+      threadTs: parsed.threadTs,
+    };
+  }
+
+  if (!options.channel || !options.timestamp) {
+    throw new FileError('--channel and --timestamp must be specified together');
+  }
+
+  return {
+    channel: options.channel,
+    messageTs: options.timestamp,
+    threadTs: options.thread,
+  };
+}
+
+function parseSlackMessageUrl(value: string): ParsedSlackMessageUrl {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new FileError(`Invalid Slack message URL: ${value}`);
+  }
+
+  const match = url.pathname.match(/\/archives\/([^/]+)\/p(\d+)/);
+  if (!match) {
+    throw new FileError(`Invalid Slack message URL: ${value}`);
+  }
+
+  return {
+    channel: match[1],
+    messageTs: permalinkTimestampToSlackTs(match[2]),
+    threadTs: url.searchParams.get('thread_ts') || undefined,
+  };
+}
+
+function permalinkTimestampToSlackTs(value: string): string {
+  if (value.length <= 10) {
+    throw new FileError(`Invalid Slack permalink timestamp: ${value}`);
+  }
+
+  return `${value.slice(0, 10)}.${value.slice(10)}`;
+}
+
+function parseFileIndex(value?: string): number {
+  const rawValue = (value || '1').trim();
+
+  if (!/^\d+$/.test(rawValue)) {
+    throw new FileError('--index must be a positive integer');
+  }
+
+  const fileIndex = Number.parseInt(rawValue, 10);
+
+  if (fileIndex < 1) {
+    throw new FileError('--index must be a positive integer');
+  }
+
+  return fileIndex;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { setupChannelsCommand } from './commands/channels';
 import { setupConfigCommand } from './commands/config';
 import { setupDeleteCommand } from './commands/delete';
 import { setupEditCommand } from './commands/edit';
+import { setupFileCommand } from './commands/file';
 import { setupHistoryCommand } from './commands/history';
 import { setupInviteCommand } from './commands/invite';
 import { setupJoinCommand } from './commands/join';
@@ -56,6 +57,7 @@ export function createProgram(): Command {
   program.addCommand(setupEditCommand());
   program.addCommand(setupDeleteCommand());
   program.addCommand(setupUploadCommand());
+  program.addCommand(setupFileCommand());
   program.addCommand(setupReactionCommand());
   program.addCommand(setupPinCommand());
   program.addCommand(setupUsersCommand());

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -79,6 +79,18 @@ export interface UploadOptions {
   profile?: string;
 }
 
+export interface FileDownloadOptions {
+  id?: string;
+  url?: string;
+  channel?: string;
+  timestamp?: string;
+  thread?: string;
+  index?: string;
+  output?: string;
+  dir?: string;
+  profile?: string;
+}
+
 export interface EditOptions {
   channel: string;
   ts: string;

--- a/src/types/slack.ts
+++ b/src/types/slack.ts
@@ -183,6 +183,18 @@ export interface Message {
   reply_count?: number;
   attachments?: unknown[];
   blocks?: unknown[];
+  files?: SlackFile[];
+}
+
+export interface SlackFile {
+  id?: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  filetype?: string;
+  size?: number;
+  url_private?: string;
+  url_private_download?: string;
 }
 
 export interface ScheduledMessage {

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -27,7 +27,11 @@ import type {
 import { createSlackClientContext } from './slack-operations/base-client';
 import { CanvasOperations } from './slack-operations/canvas-operations';
 import { ChannelOperations } from './slack-operations/channel-operations';
-import type { UploadFileOptions } from './slack-operations/file-operations';
+import type {
+  DownloadFileOptions,
+  DownloadFileResult,
+  UploadFileOptions,
+} from './slack-operations/file-operations';
 import { FileOperations } from './slack-operations/file-operations';
 import { MessageOperations } from './slack-operations/message-operations';
 import { PinOperations } from './slack-operations/pin-operations';
@@ -156,6 +160,10 @@ export class SlackApiClient {
 
   async uploadFile(options: UploadFileOptions): Promise<void> {
     return this.fileOps.uploadFile(options);
+  }
+
+  async downloadFile(options: DownloadFileOptions): Promise<DownloadFileResult> {
+    return this.fileOps.downloadFile(options);
   }
 
   async addReaction(channel: string, timestamp: string, emoji: string): Promise<void> {

--- a/src/utils/slack-operations/base-client.ts
+++ b/src/utils/slack-operations/base-client.ts
@@ -5,6 +5,7 @@ import { RATE_LIMIT } from '../constants';
 export interface SharedSlackClientContext {
   client: WebClient;
   rateLimiter: ReturnType<typeof pLimit>;
+  token?: string;
 }
 
 export type SlackClientDependency = string | WebClient | SharedSlackClientContext;
@@ -18,24 +19,28 @@ export function createSlackClientContext(token: string): SharedSlackClientContex
       logLevel: LogLevel.ERROR, // Reduce noise from WebClient logs
     }),
     rateLimiter: pLimit(RATE_LIMIT.CONCURRENT_REQUESTS),
+    token,
   };
 }
 
 export class BaseSlackClient {
   protected client: WebClient;
   protected rateLimiter: ReturnType<typeof pLimit>;
+  protected token?: string;
 
   constructor(dependency: SlackClientDependency) {
     if (typeof dependency === 'string') {
       const context = createSlackClientContext(dependency);
       this.client = context.client;
       this.rateLimiter = context.rateLimiter;
+      this.token = context.token;
       return;
     }
 
     if ('client' in dependency && 'rateLimiter' in dependency) {
       this.client = dependency.client;
       this.rateLimiter = dependency.rateLimiter;
+      this.token = dependency.token;
       return;
     }
 

--- a/src/utils/slack-operations/file-operations.ts
+++ b/src/utils/slack-operations/file-operations.ts
@@ -1,4 +1,7 @@
-import { basename } from 'path';
+import * as fs from 'fs/promises';
+import { basename, dirname, join } from 'path';
+import { Message, SlackFile } from '../../types/slack';
+import { FileError } from '../errors';
 import { BaseSlackClient, SlackClientDependency } from './base-client';
 import { ChannelOperations } from './channel-operations';
 
@@ -11,6 +14,22 @@ export interface UploadFileOptions {
   initialComment?: string;
   snippetType?: string;
   threadTs?: string;
+}
+
+export interface DownloadFileOptions {
+  fileId?: string;
+  channel?: string;
+  messageTs?: string;
+  threadTs?: string;
+  fileIndex?: number;
+  outputPath?: string;
+  outputDir?: string;
+}
+
+export interface DownloadFileResult {
+  file: SlackFile;
+  path: string;
+  bytes: number;
 }
 
 export class FileOperations extends BaseSlackClient {
@@ -44,5 +63,164 @@ export class FileOperations extends BaseSlackClient {
     await this.client.files.uploadV2(
       params as unknown as Parameters<typeof this.client.files.uploadV2>[0]
     );
+  }
+
+  async downloadFile(options: DownloadFileOptions): Promise<DownloadFileResult> {
+    const file = options.fileId
+      ? await this.getFileInfo(options.fileId)
+      : await this.getMessageFile(options);
+    const outputPath = await this.resolveOutputPath(file, options);
+    const url = file.url_private_download || file.url_private;
+
+    if (!url) {
+      throw new FileError('Selected Slack file does not include a private download URL');
+    }
+
+    const response = await this.fetchSlackFile(url);
+    if (!response.ok) {
+      throw new FileError(
+        `Failed to download Slack file: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('text/html')) {
+      throw new FileError(
+        'Slack returned HTML instead of the file. Verify the token has files:read and access to the file.'
+      );
+    }
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+    await fs.mkdir(dirname(outputPath), { recursive: true });
+    await fs.writeFile(outputPath, bytes);
+
+    return { file, path: outputPath, bytes: bytes.length };
+  }
+
+  private async getFileInfo(fileId: string): Promise<SlackFile> {
+    const response = await this.client.files.info({ file: fileId });
+    const file = response.file as SlackFile | undefined;
+
+    if (!file) {
+      throw new FileError(`Slack file not found: ${fileId}`);
+    }
+
+    return file;
+  }
+
+  private async getMessageFile(options: DownloadFileOptions): Promise<SlackFile> {
+    if (!options.channel || !options.messageTs) {
+      throw new FileError(
+        'Channel and message timestamp are required when file id is not specified'
+      );
+    }
+
+    const message = await this.getMessage(options.channel, options.messageTs, options.threadTs);
+    const files = message.files || [];
+
+    if (files.length === 0) {
+      throw new FileError(`No files found on message ${options.messageTs}`);
+    }
+
+    const fileIndex = options.fileIndex ?? 1;
+    const file = files[fileIndex - 1];
+
+    if (!file) {
+      throw new FileError(
+        `File index ${fileIndex} is out of range. Message has ${files.length} file(s).`
+      );
+    }
+
+    return file;
+  }
+
+  private async getMessage(
+    channel: string,
+    messageTs: string,
+    threadTs?: string
+  ): Promise<Message> {
+    const channelId = await this.channelOps.resolveChannelId(channel);
+
+    if (threadTs) {
+      let cursor: string | undefined;
+      do {
+        const response = await this.client.conversations.replies({
+          channel: channelId,
+          ts: threadTs,
+          cursor,
+        });
+        const messages = (response.messages || []) as Message[];
+        const message = messages.find((item) => item.ts === messageTs);
+        if (message) return message;
+        cursor = response.response_metadata?.next_cursor || undefined;
+      } while (cursor);
+
+      throw new FileError(`Message ${messageTs} was not found in thread ${threadTs}`);
+    }
+
+    const response = await this.client.conversations.history({
+      channel: channelId,
+      latest: messageTs,
+      inclusive: true,
+      limit: 1,
+    });
+    const messages = (response.messages || []) as Message[];
+    const message = messages.find((item) => item.ts === messageTs);
+
+    if (!message) {
+      throw new FileError(`Message ${messageTs} was not found in channel ${channel}`);
+    }
+
+    return message;
+  }
+
+  private async resolveOutputPath(file: SlackFile, options: DownloadFileOptions): Promise<string> {
+    if (options.outputPath) {
+      return options.outputPath;
+    }
+
+    const outputDir = options.outputDir || '.';
+    const filename = basename(file.name || file.title || file.id || 'slack-file');
+    await fs.mkdir(outputDir, { recursive: true });
+
+    return join(outputDir, filename);
+  }
+
+  private async fetchSlackFile(url: string, redirectCount = 0): Promise<Response> {
+    if (!this.token) {
+      throw new FileError('Slack token is required to download private files');
+    }
+
+    const headers = this.shouldSendAuth(url)
+      ? { Authorization: `Bearer ${this.token}` }
+      : undefined;
+    const response = await fetch(url, {
+      headers,
+      redirect: 'manual',
+    });
+
+    if (!this.isRedirect(response.status)) {
+      return response;
+    }
+
+    if (redirectCount >= 5) {
+      throw new FileError('Too many redirects while downloading Slack file');
+    }
+
+    const location = response.headers.get('location');
+    if (!location) {
+      throw new FileError('Slack file download redirected without a Location header');
+    }
+
+    return this.fetchSlackFile(new URL(location, url).toString(), redirectCount + 1);
+  }
+
+  private shouldSendAuth(url: string): boolean {
+    const hostname = new URL(url).hostname;
+    return hostname === 'slack.com' || hostname.endsWith('.slack.com');
+  }
+
+  private isRedirect(status: number): boolean {
+    return [301, 302, 303, 307, 308].includes(status);
   }
 }

--- a/tests/commands/file.test.ts
+++ b/tests/commands/file.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupFileCommand } from '../../src/commands/file';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { createTestProgram, restoreMocks, setupMockConsole } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('file command', () => {
+  let program: ReturnType<typeof createTestProgram>;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: ReturnType<typeof setupMockConsole>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockImplementation(function () {
+      return mockConfigManager;
+    });
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockImplementation(function () {
+      return mockSlackClient;
+    });
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupFileCommand());
+  });
+
+  afterEach(() => {
+    restoreMocks();
+  });
+
+  describe('download', () => {
+    it('should download from a Slack message URL', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.downloadFile).mockResolvedValue({
+        file: { id: 'F123', name: 'image.png' },
+        path: '/tmp/image.png',
+        bytes: 1234,
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'file',
+        'download',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780530261218279?thread_ts=1780527015.228619',
+        '--dir',
+        '/tmp',
+      ]);
+
+      expect(mockSlackClient.downloadFile).toHaveBeenCalledWith({
+        fileId: undefined,
+        channel: 'C123',
+        messageTs: '1780530261.218279',
+        threadTs: '1780527015.228619',
+        fileIndex: 1,
+        outputPath: undefined,
+        outputDir: '/tmp',
+      });
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Downloaded image.png to /tmp/image.png')
+      );
+    });
+
+    it('should download by file id', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.downloadFile).mockResolvedValue({
+        file: { id: 'F123', name: 'image.png' },
+        path: 'image.png',
+        bytes: 1234,
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'file',
+        'download',
+        '--id',
+        'F123',
+        '--output',
+        'image.png',
+      ]);
+
+      expect(mockSlackClient.downloadFile).toHaveBeenCalledWith({
+        fileId: 'F123',
+        channel: undefined,
+        messageTs: undefined,
+        threadTs: undefined,
+        fileIndex: 1,
+        outputPath: 'image.png',
+        outputDir: undefined,
+      });
+    });
+
+    it('should download from channel and message timestamp', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.downloadFile).mockResolvedValue({
+        file: { id: 'F123', name: 'image.png' },
+        path: 'image.png',
+        bytes: 1234,
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'file',
+        'download',
+        '-c',
+        'C123',
+        '-t',
+        '1780530261.218279',
+        '--thread',
+        '1780527015.228619',
+        '--index',
+        '2',
+      ]);
+
+      expect(mockSlackClient.downloadFile).toHaveBeenCalledWith({
+        fileId: undefined,
+        channel: 'C123',
+        messageTs: '1780530261.218279',
+        threadTs: '1780527015.228619',
+        fileIndex: 2,
+        outputPath: undefined,
+        outputDir: '.',
+      });
+    });
+  });
+
+  describe('validation', () => {
+    it('should fail when multiple sources are specified', async () => {
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'file',
+        'download',
+        '--id',
+        'F123',
+        '--url',
+        'https://example.com',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('Specify exactly one source')
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should fail when channel is missing timestamp', async () => {
+      await program.parseAsync(['node', 'slack-cli', 'file', 'download', '-c', 'C123']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('--channel and --timestamp must be specified together')
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should fail when index is invalid', async () => {
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'file',
+        'download',
+        '--id',
+        'F123',
+        '--index',
+        '0',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('--index must be a positive integer')
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it.each([
+      '1.5',
+      '2abc',
+    ])('should fail when index is not an integer string: %s', async (index) => {
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'file',
+        'download',
+        '--id',
+        'F123',
+        '--index',
+        index,
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('--index must be a positive integer')
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/utils/slack-operations/file-operations.test.ts
+++ b/tests/utils/slack-operations/file-operations.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { channelResolver } from '../../../src/utils/channel-resolver';
 import { FileOperations } from '../../../src/utils/slack-operations/file-operations';
 
@@ -6,7 +7,12 @@ vi.mock('@slack/web-api', () => ({
   WebClient: vi.fn().mockImplementation(function () {
     return {
       files: {
+        info: vi.fn(),
         uploadV2: vi.fn(),
+      },
+      conversations: {
+        history: vi.fn(),
+        replies: vi.fn(),
       },
     };
   }),
@@ -16,21 +22,41 @@ vi.mock('@slack/web-api', () => ({
 }));
 
 vi.mock('../../../src/utils/channel-resolver');
+vi.mock('fs/promises');
 
 describe('FileOperations', () => {
   type MockClient = {
     files: {
+      info: ReturnType<typeof vi.fn>;
       uploadV2: ReturnType<typeof vi.fn>;
+    };
+    conversations: {
+      history: ReturnType<typeof vi.fn>;
+      replies: ReturnType<typeof vi.fn>;
     };
   };
 
   let fileOps: FileOperations;
   let mockClient: MockClient;
+  let fetchMock: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchMock = vi.fn().mockResolvedValue(
+      new Response(Buffer.from('file-bytes'), {
+        status: 200,
+        headers: { 'content-type': 'image/png' },
+      })
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.mocked(fs.mkdir).mockResolvedValue(undefined);
+    vi.mocked(fs.writeFile).mockResolvedValue(undefined);
     fileOps = new FileOperations('test-token');
     mockClient = (fileOps as unknown as { client: MockClient }).client;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   describe('uploadFile', () => {
@@ -122,6 +148,99 @@ describe('FileOperations', () => {
           filePath: '/path/to/file.txt',
         })
       ).rejects.toThrow('not_allowed_token_type');
+    });
+  });
+
+  describe('downloadFile', () => {
+    it('should download by file id', async () => {
+      mockClient.files.info.mockResolvedValue({
+        file: {
+          id: 'F123',
+          name: 'image.png',
+          url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+        },
+      });
+
+      const result = await fileOps.downloadFile({
+        fileId: 'F123',
+        outputDir: '/tmp',
+      });
+
+      expect(mockClient.files.info).toHaveBeenCalledWith({ file: 'F123' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://files.slack.com/files-pri/T123-F123/image.png',
+        {
+          headers: { Authorization: 'Bearer test-token' },
+          redirect: 'manual',
+        }
+      );
+      expect(fs.writeFile).toHaveBeenCalledWith('/tmp/image.png', Buffer.from('file-bytes'));
+      expect(result).toEqual({
+        file: {
+          id: 'F123',
+          name: 'image.png',
+          url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+        },
+        path: '/tmp/image.png',
+        bytes: 10,
+      });
+    });
+
+    it('should download a file attached to a thread message', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+      mockClient.conversations.replies.mockResolvedValue({
+        messages: [
+          {
+            type: 'message',
+            ts: '1780530261.218279',
+            files: [
+              {
+                id: 'F123',
+                name: 'image.png',
+                url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+              },
+            ],
+          },
+        ],
+      });
+
+      await fileOps.downloadFile({
+        channel: 'general',
+        messageTs: '1780530261.218279',
+        threadTs: '1780527015.228619',
+        outputPath: '/tmp/custom.png',
+      });
+
+      expect(channelResolver.resolveChannelId).toHaveBeenCalledWith(
+        'general',
+        expect.any(Function)
+      );
+      expect(mockClient.conversations.replies).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        ts: '1780527015.228619',
+        cursor: undefined,
+      });
+      expect(fs.writeFile).toHaveBeenCalledWith('/tmp/custom.png', Buffer.from('file-bytes'));
+    });
+
+    it('should reject HTML responses', async () => {
+      mockClient.files.info.mockResolvedValue({
+        file: {
+          id: 'F123',
+          name: 'image.png',
+          url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+        },
+      });
+      fetchMock.mockResolvedValueOnce(
+        new Response('<html></html>', {
+          status: 200,
+          headers: { 'content-type': 'text/html; charset=utf-8' },
+        })
+      );
+
+      await expect(fileOps.downloadFile({ fileId: 'F123' })).rejects.toThrow(
+        'Slack returned HTML instead of the file'
+      );
     });
   });
 });


### PR DESCRIPTION
# 背景

- Slack 投稿に添付された画像などのファイルを CLI から取得できるようにする。
- 既存の `upload` はあったが、Slack file のダウンロード導線がなかった。

# 概要

- `slack-cli file download` コマンドを追加。
- Slack message permalink、Slack file ID、channel + timestamp の 3 通りでダウンロード元を指定可能にした。
- 投稿 URL から channel、message timestamp、thread timestamp を解釈し、Slack API で投稿内の添付ファイルを取得する。
- private file URL を token 付きで取得し、redirect 先が Slack 外の場合は Authorization header を送らないようにした。
- README と unit test を追加。

# 確認方法

- `npm test`
- `npm run build`
- `npm run check`

`npm run check` は既存の Biome schema version 差分を info として表示するが、チェック自体は成功。
