### PR TITLE
バージョンを 0.20.25 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.24",
+  "version": "0.20.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.20.24",
+      "version": "0.20.25",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.24",
+  "version": "0.20.25",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
# 背景

- `v0.20.24` は GitHub Release/tag が作成済みだが、npm publish が失敗した。
- `NPM_TOKEN` 修正後に改めて release workflow を走らせるため、次の patch version に上げる。

# 概要

- `package.json` / `package-lock.json` の version を `0.20.24` から `0.20.25` に更新。

# 確認方法

- `npm run check`
- `npm run build`
- `npm test`
