### PR TITLE
Add Slack table extraction to history

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ slack-cli history -c general --since "2024-01-01 00:00:00"
 # Get complete conversation of a thread
 slack-cli history -c general --thread 1719207629.000100
 
+# Get a single message from a Slack permalink
+slack-cli history --url "https://example.slack.com/archives/C123/p1780638511660849"
+
+# Extract table blocks from a Slack permalink
+slack-cli history --url "https://example.slack.com/archives/C123/p1780638511660849" --tables
+
+# Extract table blocks as JSON
+slack-cli history --url "https://example.slack.com/archives/C123/p1780638511660849" --tables --table-format json
+
 # Output in different formats
 slack-cli history -c general --format json
 slack-cli history -c general --format simple
@@ -406,13 +415,16 @@ printf '%s\n' "$NEW_TOKEN" | slack-cli config set --token-stdin
 
 ### history command
 
-| Option    | Short | Description                                            |
-| --------- | ----- | ------------------------------------------------------ |
-| --channel | -c    | Target channel name or ID (required)                   |
-| --number  | -n    | Number of messages to retrieve (default: 10)           |
-| --since   |       | Get messages since specific date (YYYY-MM-DD HH:MM:SS) |
-| --thread  | -t    | Thread timestamp to retrieve complete thread messages   |
-| --format  |       | Output format: table, simple, json (default: table)    |
+| Option         | Short | Description                                            |
+| -------------- | ----- | ------------------------------------------------------ |
+| --url          |       | Slack message permalink to retrieve                    |
+| --channel      | -c    | Target channel name or ID                              |
+| --number       | -n    | Number of messages to retrieve (default: 10)           |
+| --since        |       | Get messages since specific date (YYYY-MM-DD HH:MM:SS) |
+| --thread       | -t    | Thread timestamp to retrieve complete thread messages   |
+| --format       |       | Output format: table, simple, json (default: table)    |
+| --tables       |       | Extract table blocks from retrieved messages           |
+| --table-format |       | Table output format: markdown, json, tsv               |
 
 ### unread command
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.26",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.20.26",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.20.26",
+  "version": "0.21.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/file.ts
+++ b/src/commands/file.ts
@@ -5,13 +5,8 @@ import { createSlackClient } from '../utils/client-factory';
 import { wrapCommand } from '../utils/command-wrapper';
 import { FileError } from '../utils/errors';
 import { parseProfile } from '../utils/option-parsers';
+import { parseSlackMessageUrl } from '../utils/slack-message-url';
 import { sanitizeTerminalText } from '../utils/terminal-sanitizer';
-
-interface ParsedSlackMessageUrl {
-  channel: string;
-  messageTs: string;
-  threadTs?: string;
-}
 
 export function setupFileCommand(): Command {
   const fileCommand = new Command('file').description('Manage Slack files');
@@ -99,34 +94,6 @@ function resolveDownloadSource(options: FileDownloadOptions): {
     messageTs: options.timestamp,
     threadTs: options.thread,
   };
-}
-
-function parseSlackMessageUrl(value: string): ParsedSlackMessageUrl {
-  let url: URL;
-  try {
-    url = new URL(value);
-  } catch {
-    throw new FileError(`Invalid Slack message URL: ${value}`);
-  }
-
-  const match = url.pathname.match(/\/archives\/([^/]+)\/p(\d+)/);
-  if (!match) {
-    throw new FileError(`Invalid Slack message URL: ${value}`);
-  }
-
-  return {
-    channel: match[1],
-    messageTs: permalinkTimestampToSlackTs(match[2]),
-    threadTs: url.searchParams.get('thread_ts') || undefined,
-  };
-}
-
-function permalinkTimestampToSlackTs(value: string): string {
-  if (value.length <= 10) {
-    throw new FileError(`Invalid Slack permalink timestamp: ${value}`);
-  }
-
-  return `${value.slice(0, 10)}.${value.slice(10)}`;
 }
 
 function parseFileIndex(value?: string): number {

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -82,7 +82,8 @@ export function setupHistoryCommand(): Command {
           }
 
           if (options.tables) {
-            displaySlackTables(messages, parseTableOutputFormat(options.tableFormat));
+            const orderedMessages = preserveOrder ? messages : [...messages].reverse();
+            displaySlackTables(orderedMessages, parseTableOutputFormat(options.tableFormat));
             return;
           }
 

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -53,8 +53,18 @@ export function setupHistoryCommand(): Command {
 
           if (options.url) {
             const source = parseSlackMessageUrl(options.url);
-            messages = [await client.getMessage(source.channel, source.messageTs, source.threadTs)];
-            users = new Map();
+            if (options.tables) {
+              messages = [
+                await client.getMessage(source.channel, source.messageTs, source.threadTs),
+              ];
+              users = new Map();
+            } else {
+              ({ messages, users } = await client.getMessageWithUsers(
+                source.channel,
+                source.messageTs,
+                source.threadTs
+              ));
+            }
             channelName = source.channel;
             preserveOrder = true;
           } else if (options.thread) {

--- a/src/commands/history.ts
+++ b/src/commands/history.ts
@@ -5,6 +5,8 @@ import { withSlackClient } from '../utils/command-support';
 import { wrapCommand } from '../utils/command-wrapper';
 import { API_LIMITS } from '../utils/constants';
 import { parseCount, parseFormat } from '../utils/option-parsers';
+import { parseSlackMessageUrl } from '../utils/slack-message-url';
+import { displaySlackTables, parseTableOutputFormat } from '../utils/slack-table-blocks';
 import { createValidationHook, optionValidators } from '../utils/validators';
 import { displayHistoryResults } from './history-display';
 import { prepareSinceTimestamp } from './history-validators';
@@ -12,19 +14,25 @@ import { prepareSinceTimestamp } from './history-validators';
 export function setupHistoryCommand(): Command {
   const historyCommand = new Command('history')
     .description('Get message history from a Slack channel')
-    .requiredOption('-c, --channel <channel>', 'Target channel name or ID')
+    .option('--url <url>', 'Slack message permalink to retrieve')
+    .option('-c, --channel <channel>', 'Target channel name or ID')
     .option('-n, --number <number>', 'Number of messages to retrieve')
     .option('--since <date>', 'Get messages since specific date (YYYY-MM-DD HH:MM:SS)')
     .option('-t, --thread <thread>', 'Thread timestamp to retrieve complete thread conversation')
     .option('--with-link', 'Include permalink URL for each message', false)
     .option('--format <format>', 'Output format: table, simple, json', 'table')
+    .option('--tables', 'Extract table blocks from retrieved messages', false)
+    .option('--table-format <format>', 'Table output format: markdown, json, tsv', 'markdown')
     .option('--profile <profile>', 'Use specific workspace profile')
     .hook(
       'preAction',
       createValidationHook([
+        validateHistorySource,
+        validateSlackMessageUrl,
+        validateTableFormat,
         (options) => (options.thread ? null : optionValidators.messageCount(options)),
         (options) => (options.thread ? null : optionValidators.sinceDate(options)),
-        optionValidators.threadTimestamp,
+        (options) => (options.url ? null : optionValidators.threadTimestamp(options)),
         optionValidators.format,
       ])
     )
@@ -40,14 +48,25 @@ export function setupHistoryCommand(): Command {
 
           let messages: Message[];
           let users: Map<string, string>;
-          if (options.thread) {
+          let channelName: string;
+          let preserveOrder = false;
+
+          if (options.url) {
+            const source = parseSlackMessageUrl(options.url);
+            messages = [await client.getMessage(source.channel, source.messageTs, source.threadTs)];
+            users = new Map();
+            channelName = source.channel;
+            preserveOrder = true;
+          } else if (options.thread) {
             if (options.number !== undefined) {
               console.log('Warning: --number is ignored when --thread is specified.');
             }
             if (options.since !== undefined) {
               console.log('Warning: --since is ignored when --thread is specified.');
             }
-            ({ messages, users } = await client.getThreadHistory(options.channel, options.thread));
+            ({ messages, users } = await client.getThreadHistory(options.channel!, options.thread));
+            channelName = options.channel!;
+            preserveOrder = true;
           } else {
             const historyOptions: ApiHistoryOptions = {
               limit,
@@ -58,14 +77,20 @@ export function setupHistoryCommand(): Command {
               historyOptions.oldest = oldest;
             }
 
-            ({ messages, users } = await client.getHistory(options.channel, historyOptions));
+            ({ messages, users } = await client.getHistory(options.channel!, historyOptions));
+            channelName = options.channel!;
+          }
+
+          if (options.tables) {
+            displaySlackTables(messages, parseTableOutputFormat(options.tableFormat));
+            return;
           }
 
           let permalinks: Map<string, string> | undefined;
           if (options.withLink && messages.length > 0) {
             try {
               permalinks = await client.getPermalinks(
-                options.channel,
+                channelName,
                 messages.map((m) => m.ts)
               );
             } catch {
@@ -74,8 +99,8 @@ export function setupHistoryCommand(): Command {
           }
 
           const format = parseFormat(options.format);
-          displayHistoryResults(messages, users, options.channel, format, {
-            preserveOrder: Boolean(options.thread),
+          displayHistoryResults(messages, users, channelName, format, {
+            preserveOrder,
             permalinks,
           });
         });
@@ -83,4 +108,42 @@ export function setupHistoryCommand(): Command {
     );
 
   return historyCommand;
+}
+
+function validateHistorySource(options: Record<string, unknown>): string | null {
+  if (options.url && options.channel) {
+    return 'Cannot use --url with --channel';
+  }
+
+  if (options.url && (options.number || options.since || options.thread)) {
+    return 'Cannot use --url with --number, --since, or --thread';
+  }
+
+  if (!options.url && !options.channel) {
+    return '--channel is required unless --url is specified';
+  }
+
+  return null;
+}
+
+function validateSlackMessageUrl(options: Record<string, unknown>): string | null {
+  if (!options.url) {
+    return null;
+  }
+
+  try {
+    parseSlackMessageUrl(options.url as string);
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Invalid Slack message URL';
+  }
+}
+
+function validateTableFormat(options: Record<string, unknown>): string | null {
+  try {
+    parseTableOutputFormat(options.tableFormat as string | undefined);
+    return null;
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Invalid table format';
+  }
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -49,12 +49,15 @@ export interface ChannelsOptions {
 }
 
 export interface HistoryOptions {
-  channel: string;
+  channel?: string;
+  url?: string;
   number?: string;
   since?: string;
   thread?: string;
   withLink?: boolean;
   format?: 'table' | 'simple' | 'json';
+  tables?: boolean;
+  tableFormat?: 'markdown' | 'json' | 'tsv';
   profile?: string;
 }
 

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -15,6 +15,7 @@ import type {
   HistoryOptions,
   HistoryResult,
   ListChannelsOptions,
+  Message,
   PinnedItem,
   Reminder,
   ScheduledMessage,
@@ -131,6 +132,10 @@ export class SlackApiClient {
 
   async getThreadHistory(channel: string, threadTs: string): Promise<HistoryResult> {
     return this.messageOps.getThreadHistory(channel, threadTs);
+  }
+
+  async getMessage(channel: string, messageTs: string, threadTs?: string): Promise<Message> {
+    return this.messageOps.getMessage(channel, messageTs, threadTs);
   }
 
   async listUnreadChannels(): Promise<Channel[]> {

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -138,6 +138,14 @@ export class SlackApiClient {
     return this.messageOps.getMessage(channel, messageTs, threadTs);
   }
 
+  async getMessageWithUsers(
+    channel: string,
+    messageTs: string,
+    threadTs?: string
+  ): Promise<HistoryResult> {
+    return this.messageOps.getMessageWithUsers(channel, messageTs, threadTs);
+  }
+
   async listUnreadChannels(): Promise<Channel[]> {
     try {
       const channels = await this.searchOps.listUnreadChannels();

--- a/src/utils/slack-message-url.ts
+++ b/src/utils/slack-message-url.ts
@@ -19,17 +19,26 @@ export function parseSlackMessageUrl(value: string): ParsedSlackMessageUrl {
     throw new ValidationError(`Invalid Slack message URL: ${value}`);
   }
 
+  const threadTs = url.searchParams.get('thread_ts') || undefined;
+  if (threadTs && !isSlackTimestamp(threadTs)) {
+    throw new ValidationError('Invalid thread timestamp format');
+  }
+
   return {
     channel: match[1],
     messageTs: permalinkTimestampToSlackTs(match[2]),
-    threadTs: url.searchParams.get('thread_ts') || undefined,
+    threadTs,
   };
 }
 
 export function permalinkTimestampToSlackTs(value: string): string {
-  if (value.length <= 10) {
+  if (!/^\d{16}$/.test(value)) {
     throw new ValidationError(`Invalid Slack permalink timestamp: ${value}`);
   }
 
   return `${value.slice(0, 10)}.${value.slice(10)}`;
+}
+
+function isSlackTimestamp(value: string): boolean {
+  return /^\d{10}\.\d{6}$/.test(value);
 }

--- a/src/utils/slack-message-url.ts
+++ b/src/utils/slack-message-url.ts
@@ -1,0 +1,35 @@
+import { ValidationError } from './errors';
+
+export interface ParsedSlackMessageUrl {
+  channel: string;
+  messageTs: string;
+  threadTs?: string;
+}
+
+export function parseSlackMessageUrl(value: string): ParsedSlackMessageUrl {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new ValidationError(`Invalid Slack message URL: ${value}`);
+  }
+
+  const match = url.pathname.match(/\/archives\/([^/]+)\/p(\d+)/);
+  if (!match) {
+    throw new ValidationError(`Invalid Slack message URL: ${value}`);
+  }
+
+  return {
+    channel: match[1],
+    messageTs: permalinkTimestampToSlackTs(match[2]),
+    threadTs: url.searchParams.get('thread_ts') || undefined,
+  };
+}
+
+export function permalinkTimestampToSlackTs(value: string): string {
+  if (value.length <= 10) {
+    throw new ValidationError(`Invalid Slack permalink timestamp: ${value}`);
+  }
+
+  return `${value.slice(0, 10)}.${value.slice(10)}`;
+}

--- a/src/utils/slack-operations/file-operations.ts
+++ b/src/utils/slack-operations/file-operations.ts
@@ -1,9 +1,10 @@
 import * as fs from 'fs/promises';
 import { basename, dirname, join } from 'path';
-import { Message, SlackFile } from '../../types/slack';
+import { SlackFile } from '../../types/slack';
 import { FileError } from '../errors';
-import { BaseSlackClient, SlackClientDependency } from './base-client';
+import { BaseSlackClient, createSlackClientContext, SlackClientDependency } from './base-client';
 import { ChannelOperations } from './channel-operations';
+import { MessageHistoryOperations } from './message-history-operations';
 
 export interface UploadFileOptions {
   channel: string;
@@ -35,10 +36,15 @@ export interface DownloadFileResult {
 
 export class FileOperations extends BaseSlackClient {
   private channelOps: ChannelOperations;
+  private historyOps: MessageHistoryOperations;
 
   constructor(dependency: SlackClientDependency, channelOps?: ChannelOperations) {
-    super(dependency);
-    this.channelOps = channelOps ?? new ChannelOperations(dependency);
+    const sharedDependency =
+      typeof dependency === 'string' ? createSlackClientContext(dependency) : dependency;
+
+    super(sharedDependency);
+    this.channelOps = channelOps ?? new ChannelOperations(sharedDependency);
+    this.historyOps = new MessageHistoryOperations(sharedDependency, this.channelOps);
   }
 
   async uploadFile(options: UploadFileOptions): Promise<void> {
@@ -127,7 +133,11 @@ export class FileOperations extends BaseSlackClient {
       );
     }
 
-    const message = await this.getMessage(options.channel, options.messageTs, options.threadTs);
+    const message = await this.historyOps.getMessage(
+      options.channel,
+      options.messageTs,
+      options.threadTs
+    );
     const files = message.files || [];
 
     if (files.length === 0) {
@@ -144,46 +154,6 @@ export class FileOperations extends BaseSlackClient {
     }
 
     return file;
-  }
-
-  private async getMessage(
-    channel: string,
-    messageTs: string,
-    threadTs?: string
-  ): Promise<Message> {
-    const channelId = await this.channelOps.resolveChannelId(channel);
-
-    if (threadTs) {
-      let cursor: string | undefined;
-      do {
-        const response = await this.client.conversations.replies({
-          channel: channelId,
-          ts: threadTs,
-          cursor,
-        });
-        const messages = (response.messages || []) as Message[];
-        const message = messages.find((item) => item.ts === messageTs);
-        if (message) return message;
-        cursor = response.response_metadata?.next_cursor || undefined;
-      } while (cursor);
-
-      throw new FileError(`Message ${messageTs} was not found in thread ${threadTs}`);
-    }
-
-    const response = await this.client.conversations.history({
-      channel: channelId,
-      latest: messageTs,
-      inclusive: true,
-      limit: 1,
-    });
-    const messages = (response.messages || []) as Message[];
-    const message = messages.find((item) => item.ts === messageTs);
-
-    if (!message) {
-      throw new FileError(`Message ${messageTs} was not found in channel ${channel}`);
-    }
-
-    return message;
   }
 
   private async resolveOutputPath(file: SlackFile, options: DownloadFileOptions): Promise<string> {

--- a/src/utils/slack-operations/message-history-operations.ts
+++ b/src/utils/slack-operations/message-history-operations.ts
@@ -5,6 +5,7 @@ import type {
   Message,
 } from '../../types/slack';
 import { DEFAULTS, RATE_LIMIT } from '../constants';
+import { ApiError } from '../errors';
 import { extractAllUserIds } from '../mention-utils';
 import { BaseSlackClient, SlackClientDependency } from './base-client';
 import { ChannelOperations } from './channel-operations';
@@ -58,6 +59,42 @@ export class MessageHistoryOperations extends BaseSlackClient {
     const users = await this.userResolver.fetchUserInfo(extractAllUserIds(messages));
 
     return { messages, users };
+  }
+
+  async getMessage(channel: string, messageTs: string, threadTs?: string): Promise<Message> {
+    const channelId = await this.channelOps.resolveChannelId(channel);
+
+    if (threadTs) {
+      let cursor: string | undefined;
+      do {
+        const response = await this.client.conversations.replies({
+          channel: channelId,
+          ts: threadTs,
+          cursor,
+        });
+        const messages = (response.messages || []) as Message[];
+        const message = messages.find((item) => item.ts === messageTs);
+        if (message) return message;
+        cursor = response.response_metadata?.next_cursor || undefined;
+      } while (cursor);
+
+      throw new ApiError(`Message ${messageTs} was not found in thread ${threadTs}`);
+    }
+
+    const response = await this.client.conversations.history({
+      channel: channelId,
+      latest: messageTs,
+      inclusive: true,
+      limit: 1,
+    });
+    const messages = (response.messages || []) as Message[];
+    const message = messages.find((item) => item.ts === messageTs);
+
+    if (!message) {
+      throw new ApiError(`Message ${messageTs} was not found in channel ${channel}`);
+    }
+
+    return message;
   }
 
   async getChannelUnread(channelNameOrId: string): Promise<ChannelUnreadResult> {

--- a/src/utils/slack-operations/message-history-operations.ts
+++ b/src/utils/slack-operations/message-history-operations.ts
@@ -97,6 +97,18 @@ export class MessageHistoryOperations extends BaseSlackClient {
     return message;
   }
 
+  async getMessageWithUsers(
+    channel: string,
+    messageTs: string,
+    threadTs?: string
+  ): Promise<HistoryResult> {
+    const message = await this.getMessage(channel, messageTs, threadTs);
+    const messages = [message];
+    const users = await this.userResolver.fetchUserInfo(extractAllUserIds(messages));
+
+    return { messages, users };
+  }
+
   async getChannelUnread(channelNameOrId: string): Promise<ChannelUnreadResult> {
     const channel = await this.channelOps.getChannelInfo(channelNameOrId);
     const summary = await this.getUnreadMessageSummary(

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -8,6 +8,7 @@ import type {
   ChannelUnreadResult,
   HistoryOptions,
   HistoryResult,
+  Message,
   ScheduledMessage,
 } from '../../types/slack';
 import { BaseSlackClient, createSlackClientContext, SlackClientDependency } from './base-client';
@@ -87,6 +88,10 @@ export class MessageOperations extends BaseSlackClient {
 
   async getThreadHistory(channel: string, threadTs: string): Promise<HistoryResult> {
     return await this.historyOps.getThreadHistory(channel, threadTs);
+  }
+
+  async getMessage(channel: string, messageTs: string, threadTs?: string): Promise<Message> {
+    return await this.historyOps.getMessage(channel, messageTs, threadTs);
   }
 
   async getChannelUnread(channelNameOrId: string): Promise<ChannelUnreadResult> {

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -94,6 +94,14 @@ export class MessageOperations extends BaseSlackClient {
     return await this.historyOps.getMessage(channel, messageTs, threadTs);
   }
 
+  async getMessageWithUsers(
+    channel: string,
+    messageTs: string,
+    threadTs?: string
+  ): Promise<HistoryResult> {
+    return await this.historyOps.getMessageWithUsers(channel, messageTs, threadTs);
+  }
+
   async getChannelUnread(channelNameOrId: string): Promise<ChannelUnreadResult> {
     return await this.historyOps.getChannelUnread(channelNameOrId);
   }

--- a/src/utils/slack-table-blocks.ts
+++ b/src/utils/slack-table-blocks.ts
@@ -18,7 +18,7 @@ export function extractSlackTables(messages: Message[]): ExtractedSlackTable[] {
   const tables: ExtractedSlackTable[] = [];
 
   messages.forEach((message) => {
-    const blocks = Array.isArray(message.blocks) ? message.blocks : [];
+    const blocks = getMessageBlocks(message);
 
     blocks.forEach((block) => {
       if (!isTableBlock(block)) {
@@ -34,6 +34,19 @@ export function extractSlackTables(messages: Message[]): ExtractedSlackTable[] {
   });
 
   return tables;
+}
+
+function getMessageBlocks(message: Message): unknown[] {
+  const blocks = Array.isArray(message.blocks) ? [...message.blocks] : [];
+  const attachments = Array.isArray(message.attachments) ? message.attachments : [];
+
+  attachments.forEach((attachment) => {
+    if (isRecord(attachment) && Array.isArray(attachment.blocks)) {
+      blocks.push(...attachment.blocks);
+    }
+  });
+
+  return blocks;
 }
 
 export function displaySlackTables(messages: Message[], format: TableOutputFormat): void {

--- a/src/utils/slack-table-blocks.ts
+++ b/src/utils/slack-table-blocks.ts
@@ -1,0 +1,186 @@
+import type { Message } from '../types/slack';
+import { sanitizeTerminalData, sanitizeTerminalText } from './terminal-sanitizer';
+
+export type TableOutputFormat = 'markdown' | 'json' | 'tsv';
+
+export interface ExtractedSlackTable {
+  messageTs: string;
+  tableIndex: number;
+  rows: string[][];
+}
+
+interface SlackTableBlock {
+  type: 'table';
+  rows?: unknown;
+}
+
+export function extractSlackTables(messages: Message[]): ExtractedSlackTable[] {
+  const tables: ExtractedSlackTable[] = [];
+
+  messages.forEach((message) => {
+    const blocks = Array.isArray(message.blocks) ? message.blocks : [];
+
+    blocks.forEach((block) => {
+      if (!isTableBlock(block)) {
+        return;
+      }
+
+      tables.push({
+        messageTs: message.ts,
+        tableIndex: tables.length,
+        rows: block.rows.map((row) => row.map(stringifyTableCell)),
+      });
+    });
+  });
+
+  return tables;
+}
+
+export function displaySlackTables(messages: Message[], format: TableOutputFormat): void {
+  const tables = extractSlackTables(messages);
+
+  if (tables.length === 0) {
+    console.log('No tables found');
+    return;
+  }
+
+  if (format === 'json') {
+    console.log(
+      JSON.stringify(
+        sanitizeTerminalData({
+          tables: tables.map((table) => ({
+            message_ts: table.messageTs,
+            index: table.tableIndex,
+            rows: table.rows,
+          })),
+          total: tables.length,
+        }),
+        null,
+        2
+      )
+    );
+    return;
+  }
+
+  if (format === 'tsv') {
+    tables.forEach((table, index) => {
+      if (index > 0) {
+        console.log('');
+      }
+      table.rows.forEach((row) => console.log(row.map(formatTsvCell).join('\t')));
+    });
+    return;
+  }
+
+  tables.forEach((table, index) => {
+    if (index > 0) {
+      console.log('');
+    }
+    renderMarkdownTable(table.rows).forEach((line) => console.log(line));
+  });
+}
+
+export function parseTableOutputFormat(value?: string): TableOutputFormat {
+  const format = value || 'markdown';
+  if (format === 'markdown' || format === 'json' || format === 'tsv') {
+    return format;
+  }
+
+  throw new Error('Invalid table format. Must be one of: markdown, json, tsv');
+}
+
+function isTableBlock(value: unknown): value is SlackTableBlock & { rows: unknown[][] } {
+  if (!isRecord(value) || value.type !== 'table' || !Array.isArray(value.rows)) {
+    return false;
+  }
+
+  return value.rows.every((row) => Array.isArray(row));
+}
+
+function stringifyTableCell(cell: unknown): string {
+  if (!isRecord(cell)) {
+    return '';
+  }
+
+  if (cell.type === 'raw_text') {
+    return sanitizeTerminalText(String(cell.text ?? ''));
+  }
+
+  if (cell.type === 'raw_number') {
+    return sanitizeTerminalText(String(cell.value ?? cell.text ?? ''));
+  }
+
+  if (cell.type === 'rich_text') {
+    return sanitizeTerminalText(stringifyRichTextElements(cell.elements));
+  }
+
+  return '';
+}
+
+function stringifyRichTextElements(elements: unknown): string {
+  if (!Array.isArray(elements)) {
+    return '';
+  }
+
+  return elements.map(stringifyRichTextElement).join('');
+}
+
+function stringifyRichTextElement(element: unknown): string {
+  if (!isRecord(element)) {
+    return '';
+  }
+
+  if (typeof element.text === 'string') {
+    return element.text;
+  }
+
+  if (element.type === 'link') {
+    return String(element.url ?? '');
+  }
+
+  if (element.type === 'user' && typeof element.user_id === 'string') {
+    return `<@${element.user_id}>`;
+  }
+
+  if (element.type === 'emoji' && typeof element.name === 'string') {
+    return `:${element.name}:`;
+  }
+
+  return stringifyRichTextElements(element.elements);
+}
+
+function renderMarkdownTable(rows: string[][]): string[] {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const columnCount = Math.max(...rows.map((row) => row.length), 1);
+  const normalizedRows = rows.map((row) => normalizeRow(row, columnCount));
+  const [header, ...body] = normalizedRows;
+
+  return [
+    markdownRow(header),
+    markdownRow(Array.from({ length: columnCount }, () => '---')),
+    ...body.map(markdownRow),
+  ];
+}
+
+function normalizeRow(row: string[], columnCount: number): string[] {
+  return Array.from({ length: columnCount }, (_, index) => row[index] ?? '');
+}
+
+function markdownRow(row: string[]): string {
+  return `| ${row.map(formatMarkdownCell).join(' | ')} |`;
+}
+
+function formatMarkdownCell(value: string): string {
+  return value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+}
+
+function formatTsvCell(value: string): string {
+  return value.replace(/\r?\n/g, ' ').replace(/\t/g, ' ');
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -137,6 +137,65 @@ describe('history command', () => {
       expect(mockSlackClient.getHistory).not.toHaveBeenCalled();
     });
 
+    it('should fetch a single message from a Slack message URL', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
+        type: 'message',
+        text: 'Linked message',
+        user: 'U123456',
+        ts: '1780638511.660849',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'history',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780638511660849',
+      ]);
+
+      expect(mockSlackClient.getMessage).toHaveBeenCalledWith(
+        'C123',
+        '1780638511.660849',
+        undefined
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Linked message'));
+    });
+
+    it('should fetch a single thread reply from a Slack message URL with thread_ts', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
+        type: 'message',
+        text: 'Linked reply',
+        user: 'U123456',
+        ts: '1780638511.660849',
+        thread_ts: '1780527015.228619',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'history',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780638511660849?thread_ts=1780527015.228619',
+      ]);
+
+      expect(mockSlackClient.getMessage).toHaveBeenCalledWith(
+        'C123',
+        '1780638511.660849',
+        '1780527015.228619'
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Linked reply'));
+    });
+
     it('should show warning when --number is used with --thread', async () => {
       vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
         token: 'test-token',
@@ -880,6 +939,196 @@ describe('history command', () => {
       await program.parseAsync(['node', 'slack-cli', 'history', '-c', 'general']);
 
       expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('No messages found'));
+    });
+
+    it('should render table blocks from a Slack message URL as Markdown by default', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
+        type: 'message',
+        text: 'Message with table',
+        user: 'U123456',
+        ts: '1780638511.660849',
+        blocks: [
+          {
+            type: 'table',
+            rows: [
+              [
+                { type: 'raw_text', text: 'Name' },
+                { type: 'raw_number', value: 42 },
+              ],
+              [
+                {
+                  type: 'rich_text',
+                  elements: [
+                    {
+                      type: 'rich_text_section',
+                      elements: [{ type: 'text', text: 'Alice' }],
+                    },
+                  ],
+                },
+                { type: 'raw_text', text: 'Done' },
+              ],
+            ],
+          },
+        ],
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'history',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780638511660849',
+        '--tables',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('| Name | 42 |');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('| --- | --- |');
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('| Alice | Done |');
+    });
+
+    it('should preserve multiple table block order', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
+        type: 'message',
+        text: 'Multiple tables',
+        user: 'U123456',
+        ts: '1780638511.660849',
+        blocks: [
+          {
+            type: 'table',
+            rows: [[{ type: 'raw_text', text: 'First' }]],
+          },
+          {
+            type: 'table',
+            rows: [[{ type: 'raw_text', text: 'Second' }]],
+          },
+        ],
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'history',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780638511660849',
+        '--tables',
+      ]);
+
+      const output = mockConsole.logSpy.mock.calls.map((call) => call[0]).join('\n');
+      expect(output.indexOf('| First |')).toBeLessThan(output.indexOf('| Second |'));
+    });
+
+    it('should render table blocks as JSON when --table-format json is specified', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
+        type: 'message',
+        text: 'Message with table',
+        user: 'U123456',
+        ts: '1780638511.660849',
+        blocks: [
+          {
+            type: 'table',
+            rows: [
+              [
+                { type: 'raw_text', text: 'Name' },
+                { type: 'raw_text', text: 'Status' },
+              ],
+              [
+                { type: 'raw_text', text: 'Alice' },
+                { type: 'raw_text', text: 'Done' },
+              ],
+            ],
+          },
+        ],
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'history',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780638511660849',
+        '--tables',
+        '--table-format',
+        'json',
+      ]);
+
+      const output = JSON.parse(mockConsole.logSpy.mock.calls[0][0]);
+      expect(output.tables[0].rows).toEqual([
+        ['Name', 'Status'],
+        ['Alice', 'Done'],
+      ]);
+    });
+
+    it('should show a message when no table blocks are found', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
+        type: 'message',
+        text: 'No tables here',
+        user: 'U123456',
+        ts: '1780638511.660849',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'history',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780638511660849',
+        '--tables',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('No tables found');
+    });
+
+    it('should reject invalid Slack message URLs', async () => {
+      const historyCommand = setupHistoryCommand();
+      historyCommand.exitOverride();
+
+      await expect(
+        historyCommand.parseAsync(['--url', 'https://example.com/not-a-message'], { from: 'user' })
+      ).rejects.toThrow();
+    });
+
+    it('should reject --url with channel based options', async () => {
+      const historyCommand = setupHistoryCommand();
+      historyCommand.exitOverride();
+
+      await expect(
+        historyCommand.parseAsync(
+          ['--url', 'https://example.slack.com/archives/C123/p1780638511660849', '-c', 'general'],
+          { from: 'user' }
+        )
+      ).rejects.toThrow();
+    });
+
+    it('should reject --url with range options', async () => {
+      const historyCommand = setupHistoryCommand();
+      historyCommand.exitOverride();
+
+      await expect(
+        historyCommand.parseAsync(
+          ['--url', 'https://example.slack.com/archives/C123/p1780638511660849', '-n', '20'],
+          { from: 'user' }
+        )
+      ).rejects.toThrow();
     });
   });
 });

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -143,11 +143,19 @@ describe('history command', () => {
         updatedAt: new Date().toISOString(),
       });
 
-      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
-        type: 'message',
-        text: 'Linked message',
-        user: 'U123456',
-        ts: '1780638511.660849',
+      vi.mocked(mockSlackClient.getMessageWithUsers).mockResolvedValue({
+        messages: [
+          {
+            type: 'message',
+            text: 'Linked message for <@U789012>',
+            user: 'U123456',
+            ts: '1780638511.660849',
+          },
+        ],
+        users: new Map([
+          ['U123456', 'john.doe'],
+          ['U789012', 'jane.smith'],
+        ]),
       });
 
       await program.parseAsync([
@@ -158,12 +166,16 @@ describe('history command', () => {
         'https://example.slack.com/archives/C123/p1780638511660849',
       ]);
 
-      expect(mockSlackClient.getMessage).toHaveBeenCalledWith(
+      expect(mockSlackClient.getMessageWithUsers).toHaveBeenCalledWith(
         'C123',
         '1780638511.660849',
         undefined
       );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('john.doe'));
       expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Linked message'));
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Linked message for @jane.smith')
+      );
     });
 
     it('should fetch a single thread reply from a Slack message URL with thread_ts', async () => {
@@ -172,12 +184,17 @@ describe('history command', () => {
         updatedAt: new Date().toISOString(),
       });
 
-      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
-        type: 'message',
-        text: 'Linked reply',
-        user: 'U123456',
-        ts: '1780638511.660849',
-        thread_ts: '1780527015.228619',
+      vi.mocked(mockSlackClient.getMessageWithUsers).mockResolvedValue({
+        messages: [
+          {
+            type: 'message',
+            text: 'Linked reply',
+            user: 'U123456',
+            ts: '1780638511.660849',
+            thread_ts: '1780527015.228619',
+          },
+        ],
+        users: new Map([['U123456', 'john.doe']]),
       });
 
       await program.parseAsync([
@@ -188,7 +205,7 @@ describe('history command', () => {
         'https://example.slack.com/archives/C123/p1780638511660849?thread_ts=1780527015.228619',
       ]);
 
-      expect(mockSlackClient.getMessage).toHaveBeenCalledWith(
+      expect(mockSlackClient.getMessageWithUsers).toHaveBeenCalledWith(
         'C123',
         '1780638511.660849',
         '1780527015.228619'

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -991,6 +991,83 @@ describe('history command', () => {
       expect(mockConsole.logSpy).toHaveBeenCalledWith('| Alice | Done |');
     });
 
+    it('should render table blocks from message attachments', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getMessage).mockResolvedValue({
+        type: 'message',
+        text: 'Message with attachment table',
+        user: 'U123456',
+        ts: '1780638511.660849',
+        attachments: [
+          {
+            blocks: [
+              {
+                type: 'table',
+                rows: [[{ type: 'raw_text', text: 'Attachment table' }]],
+              },
+            ],
+          },
+        ],
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'history',
+        '--url',
+        'https://example.slack.com/archives/C123/p1780638511660849',
+        '--tables',
+      ]);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('| Attachment table |');
+    });
+
+    it('should render channel history table blocks in chronological order', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockSlackClient.getHistory).mockResolvedValue({
+        messages: [
+          {
+            type: 'message',
+            text: 'Newer table',
+            user: 'U123456',
+            ts: '1780638520.000000',
+            blocks: [
+              {
+                type: 'table',
+                rows: [[{ type: 'raw_text', text: 'Newer' }]],
+              },
+            ],
+          },
+          {
+            type: 'message',
+            text: 'Older table',
+            user: 'U123456',
+            ts: '1780638511.660849',
+            blocks: [
+              {
+                type: 'table',
+                rows: [[{ type: 'raw_text', text: 'Older' }]],
+              },
+            ],
+          },
+        ],
+        users: new Map(),
+      });
+
+      await program.parseAsync(['node', 'slack-cli', 'history', '-c', 'general', '--tables']);
+
+      const output = mockConsole.logSpy.mock.calls.map((call) => call[0]).join('\n');
+      expect(output.indexOf('| Older |')).toBeLessThan(output.indexOf('| Newer |'));
+    });
+
     it('should preserve multiple table block order', async () => {
       vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
         token: 'test-token',

--- a/tests/utils/slack-message-url.test.ts
+++ b/tests/utils/slack-message-url.test.ts
@@ -29,4 +29,18 @@ describe('slack-message-url', () => {
       'Invalid Slack message URL'
     );
   });
+
+  it('should reject invalid Slack permalink timestamps', () => {
+    expect(() => parseSlackMessageUrl('https://example.slack.com/archives/C123/p123')).toThrow(
+      'Invalid Slack permalink timestamp'
+    );
+  });
+
+  it('should reject invalid thread_ts query parameters', () => {
+    expect(() =>
+      parseSlackMessageUrl(
+        'https://example.slack.com/archives/C123/p1780638511660849?thread_ts=invalid'
+      )
+    ).toThrow('Invalid thread timestamp format');
+  });
 });

--- a/tests/utils/slack-message-url.test.ts
+++ b/tests/utils/slack-message-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { parseSlackMessageUrl } from '../../src/utils/slack-message-url';
+
+describe('slack-message-url', () => {
+  it('should parse a Slack message permalink', () => {
+    expect(
+      parseSlackMessageUrl('https://example.slack.com/archives/C123/p1780638511660849')
+    ).toEqual({
+      channel: 'C123',
+      messageTs: '1780638511.660849',
+      threadTs: undefined,
+    });
+  });
+
+  it('should parse a Slack thread reply permalink', () => {
+    expect(
+      parseSlackMessageUrl(
+        'https://example.slack.com/archives/C123/p1780638511660849?thread_ts=1780527015.228619'
+      )
+    ).toEqual({
+      channel: 'C123',
+      messageTs: '1780638511.660849',
+      threadTs: '1780527015.228619',
+    });
+  });
+
+  it('should reject invalid Slack message permalinks', () => {
+    expect(() => parseSlackMessageUrl('https://example.com/not-a-message')).toThrow(
+      'Invalid Slack message URL'
+    );
+  });
+});

--- a/tests/utils/slack-operations/message-operations.test.ts
+++ b/tests/utils/slack-operations/message-operations.test.ts
@@ -302,6 +302,71 @@ describe('MessageOperations', () => {
     });
   });
 
+  describe('getMessage', () => {
+    it('should fetch a single channel message by timestamp', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+      mockClient.conversations.history.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            type: 'message',
+            text: 'Target message',
+            user: 'U111',
+            ts: '1234567890.000100',
+          },
+        ],
+      });
+
+      const result = await messageOps.getMessage('general', '1234567890.000100');
+
+      expect(mockClient.conversations.history).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        latest: '1234567890.000100',
+        inclusive: true,
+        limit: 1,
+      });
+      expect(result.text).toBe('Target message');
+    });
+
+    it('should fetch a single thread reply by timestamp', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+      mockClient.conversations.replies.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            type: 'message',
+            text: 'Parent',
+            user: 'U111',
+            ts: '1234567890.000100',
+          },
+          {
+            type: 'message',
+            text: 'Target reply',
+            user: 'U222',
+            ts: '1234567891.000200',
+            thread_ts: '1234567890.000100',
+          },
+        ],
+        response_metadata: {
+          next_cursor: '',
+        },
+      });
+
+      const result = await messageOps.getMessage(
+        'general',
+        '1234567891.000200',
+        '1234567890.000100'
+      );
+
+      expect(mockClient.conversations.replies).toHaveBeenCalledWith({
+        channel: 'C123456789',
+        ts: '1234567890.000100',
+        cursor: undefined,
+      });
+      expect(result.text).toBe('Target reply');
+    });
+  });
+
   describe('getChannelUnread', () => {
     it('should cap user info lookups and keep skipped unread message IDs displayable', async () => {
       const mentionedUserIds = Array.from(

--- a/tests/utils/slack-operations/message-operations.test.ts
+++ b/tests/utils/slack-operations/message-operations.test.ts
@@ -365,6 +365,33 @@ describe('MessageOperations', () => {
       });
       expect(result.text).toBe('Target reply');
     });
+
+    it('should fetch user info for a single message and its mentions', async () => {
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+      mockClient.conversations.history.mockResolvedValue({
+        ok: true,
+        messages: [
+          {
+            type: 'message',
+            text: 'Target message for <@U222222222>',
+            user: 'U111111111',
+            ts: '1234567890.000100',
+          },
+        ],
+      });
+
+      mockClient.users.info.mockImplementation(({ user }: { user: string }) => {
+        if (user === 'U111111111') return Promise.resolve({ ok: true, user: { name: 'alice' } });
+        if (user === 'U222222222') return Promise.resolve({ ok: true, user: { name: 'bob' } });
+        return Promise.resolve({ ok: false });
+      });
+
+      const result = await messageOps.getMessageWithUsers('general', '1234567890.000100');
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.users.get('U111111111')).toBe('alice');
+      expect(result.users.get('U222222222')).toBe('bob');
+    });
   });
 
   describe('getChannelUnread', () => {


### PR DESCRIPTION
# Background

- Enable the CLI to read Slack table blocks and reference them through Slack permalinks like regular messages.

# Summary

- Added `slack-cli history --url <Slack permalink>` to retrieve a single message.
- Added `slack-cli history --url <Slack permalink> --tables` to extract table blocks and render them as Markdown tables by default.
- Added `--table-format markdown|json|tsv`.
- Shared Slack permalink parsing and single-message retrieval logic, including reuse from `file download --url`.
- Bumped the package version to `0.21.0`.

# Related Information

- Jira issue: none

# Verification

- `npm test`
- `npm run build`
- `npm run check`
