### PR TITLE
Canvas write コマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,20 @@ slack-cli canvas list -c general
 slack-cli canvas list -c general --format json
 slack-cli canvas list -c general --format simple
 
+# Append markdown to an existing Canvas
+slack-cli canvas write -i F01234567890 -m "追記する内容"
+
+# Insert markdown at the start of an existing Canvas
+slack-cli canvas write -i F01234567890 -m "先頭に追加" --position start
+
+# Replace the entire Canvas content
+# This discards the current Canvas content and requires --yes.
+slack-cli canvas write -i F01234567890 -m "全体を置換" --position replace --yes
+
 # Use specific profile
 slack-cli canvas read -i F01234567890 --profile work
 slack-cli canvas list -c general --profile work
+slack-cli canvas write -i F01234567890 -m "追記する内容" --profile work
 ```
 
 ### Other Commands
@@ -562,7 +573,7 @@ Subcommands: `list`, `cancel`
 
 ### canvas command
 
-Subcommands: `read`, `list`
+Subcommands: `read`, `list`, `write`
 
 #### canvas read
 
@@ -577,6 +588,18 @@ Subcommands: `read`, `list`
 | --------- | ----- | --------------------------------------------------- |
 | --channel | -c    | Channel name or ID (required)                       |
 | --format  |       | Output format: table, simple, json (default: table) |
+
+#### canvas write
+
+Writes markdown to an existing Canvas. It does not create a new Canvas.
+
+| Option     | Short | Description                                                       |
+| ---------- | ----- | ----------------------------------------------------------------- |
+| --id       | -i    | Canvas ID (required)                                              |
+| --message  | -m    | Markdown content to write (required)                              |
+| --position |       | Write position: end, start, replace (default: end)                |
+| --yes      |       | Required when --position replace discards the whole Canvas content |
+| --profile  |       | Use specific workspace profile                                    |
 
 ## Required Permissions
 
@@ -600,6 +623,7 @@ Your Slack API token needs the following scopes:
 - `files:write` - Upload files and snippets
 - `files:read` - Download Slack files and list canvases linked to a channel
 - `canvases:read` - Read Canvas sections
+- `canvases:write` - Write Canvas content
 
 ## Advanced Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/canvas.ts
+++ b/src/commands/canvas.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import { Command } from 'commander';
-import { CanvasListOptions, CanvasReadOptions } from '../types/commands';
+import { CanvasListOptions, CanvasReadOptions, CanvasWriteOptions } from '../types/commands';
 import { CanvasFile, CanvasSection, CanvasSectionElement } from '../types/slack';
 import { renderByFormat, withSlackClient } from '../utils/command-support';
 import { wrapCommand } from '../utils/command-wrapper';
@@ -102,8 +102,33 @@ export function setupCanvasCommand(): Command {
       })
     );
 
+  const writeCommand = new Command('write')
+    .description('Write markdown to an existing Canvas')
+    .requiredOption('-i, --id <canvas-id>', 'Canvas ID')
+    .requiredOption('-m, --message <markdown>', 'Markdown content to write')
+    .option('--position <position>', 'Write position: end, start, replace', 'end')
+    .option('--yes', 'Confirm replacing the whole Canvas when --position replace is used')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook(
+      'preAction',
+      createValidationHook([
+        optionValidators.requiredMessage,
+        optionValidators.canvasPosition,
+        optionValidators.canvasReplaceConfirmation,
+      ])
+    )
+    .action(
+      wrapCommand(async (options: CanvasWriteOptions) => {
+        await withSlackClient(options, async (client) => {
+          await client.writeCanvas(options.id, options.message, options.position ?? 'end');
+          console.log('Canvas updated');
+        });
+      })
+    );
+
   canvasCommand.addCommand(readCommand);
   canvasCommand.addCommand(listCommand);
+  canvasCommand.addCommand(writeCommand);
 
   return canvasCommand;
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -263,3 +263,13 @@ export interface CanvasListOptions {
   format?: 'table' | 'simple' | 'json';
   profile?: string;
 }
+
+export type CanvasPosition = 'end' | 'start' | 'replace';
+
+export interface CanvasWriteOptions {
+  id: string;
+  message: string;
+  position?: CanvasPosition;
+  yes?: boolean;
+  profile?: string;
+}

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -4,6 +4,7 @@ import {
   ChatScheduleMessageResponse,
   ChatUpdateResponse,
 } from '@slack/web-api';
+import type { CanvasPosition } from '../types/commands';
 import type {
   CanvasFile,
   CanvasSection,
@@ -284,6 +285,10 @@ export class SlackApiClient {
 
   async listCanvases(channel: string): Promise<CanvasFile[]> {
     return this.canvasOps.listCanvases(channel);
+  }
+
+  async writeCanvas(canvasId: string, markdown: string, position: CanvasPosition): Promise<void> {
+    return this.canvasOps.writeCanvas(canvasId, markdown, position);
   }
 }
 

--- a/src/utils/slack-operations/canvas-operations.ts
+++ b/src/utils/slack-operations/canvas-operations.ts
@@ -1,6 +1,17 @@
+import type { CanvasesEditArguments } from '@slack/web-api';
+import type { CanvasPosition } from '../../types/commands';
 import type { CanvasFile, CanvasSection } from '../../types/slack';
 import { BaseSlackClient, SlackClientDependency } from './base-client';
 import { ChannelOperations } from './channel-operations';
+
+const CANVAS_POSITION_OPERATIONS: Record<
+  CanvasPosition,
+  'insert_at_end' | 'insert_at_start' | 'replace'
+> = {
+  end: 'insert_at_end',
+  start: 'insert_at_start',
+  replace: 'replace',
+};
 
 export class CanvasOperations extends BaseSlackClient {
   private channelOps: ChannelOperations;
@@ -25,5 +36,23 @@ export class CanvasOperations extends BaseSlackClient {
       types: 'spaces',
     });
     return (response.files || []) as CanvasFile[];
+  }
+
+  async writeCanvas(canvasId: string, markdown: string, position: CanvasPosition): Promise<void> {
+    const operation = CANVAS_POSITION_OPERATIONS[position];
+    const args: CanvasesEditArguments = {
+      canvas_id: canvasId,
+      changes: [
+        {
+          operation,
+          document_content: {
+            type: 'markdown',
+            markdown,
+          },
+        },
+      ],
+    };
+
+    await this.client.canvases.edit(args);
   }
 }

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -393,6 +393,29 @@ export const optionValidators = {
   },
 
   /**
+   * Validates Canvas write position option
+   */
+  canvasPosition: (options: Record<string, unknown>): string | null => {
+    if (options.position) {
+      const validPositions = ['end', 'start', 'replace'];
+      if (!validPositions.includes(options.position as string)) {
+        return `Invalid position '${options.position}'. Must be one of: ${validPositions.join(', ')}`;
+      }
+    }
+    return null;
+  },
+
+  /**
+   * Requires explicit confirmation for destructive Canvas replacement
+   */
+  canvasReplaceConfirmation: (options: Record<string, unknown>): string | null => {
+    if (options.position === 'replace' && !options.yes) {
+      return '--yes is required when --position replace is used';
+    }
+    return null;
+  },
+
+  /**
    * Validates sort option for search command
    */
   searchSort: (options: Record<string, unknown>): string | null => {

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -396,9 +396,9 @@ export const optionValidators = {
    * Validates Canvas write position option
    */
   canvasPosition: (options: Record<string, unknown>): string | null => {
-    if (options.position) {
+    if (options.position !== undefined) {
       const validPositions = ['end', 'start', 'replace'];
-      if (!validPositions.includes(options.position as string)) {
+      if (typeof options.position !== 'string' || !validPositions.includes(options.position)) {
         return `Invalid position '${options.position}'. Must be one of: ${validPositions.join(', ')}`;
       }
     }

--- a/tests/commands/canvas.test.ts
+++ b/tests/commands/canvas.test.ts
@@ -367,4 +367,178 @@ describe('canvas command', () => {
       expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
     });
   });
+
+  describe('write subcommand', () => {
+    it('should append markdown to a canvas by default', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.writeCanvas).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'canvas',
+        'write',
+        '-i',
+        'F0AJ4852CQN',
+        '-m',
+        '追記する内容',
+      ]);
+
+      expect(mockSlackClient.writeCanvas).toHaveBeenCalledWith(
+        'F0AJ4852CQN',
+        '追記する内容',
+        'end'
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith('Canvas updated');
+    });
+
+    it('should write markdown at the start when --position start is provided', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.writeCanvas).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'canvas',
+        'write',
+        '-i',
+        'F0AJ4852CQN',
+        '-m',
+        '先頭に追加',
+        '--position',
+        'start',
+      ]);
+
+      expect(mockSlackClient.writeCanvas).toHaveBeenCalledWith(
+        'F0AJ4852CQN',
+        '先頭に追加',
+        'start'
+      );
+    });
+
+    it('should require --yes when replacing the whole canvas', async () => {
+      const canvasCommand = setupCanvasCommand();
+      canvasCommand.exitOverride();
+
+      const writeCommand = canvasCommand.commands.find((c) => c.name() === 'write')!;
+      writeCommand.exitOverride();
+
+      await expect(
+        writeCommand.parseAsync(
+          ['-i', 'F0AJ4852CQN', '-m', '全体を置換', '--position', 'replace'],
+          { from: 'user' }
+        )
+      ).rejects.toThrow('Error: --yes is required when --position replace is used');
+    });
+
+    it('should replace the whole canvas when --position replace and --yes are provided', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.writeCanvas).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'canvas',
+        'write',
+        '-i',
+        'F0AJ4852CQN',
+        '-m',
+        '全体を置換',
+        '--position',
+        'replace',
+        '--yes',
+      ]);
+
+      expect(mockSlackClient.writeCanvas).toHaveBeenCalledWith(
+        'F0AJ4852CQN',
+        '全体を置換',
+        'replace'
+      );
+    });
+
+    it('should use specified profile', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'work-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.writeCanvas).mockResolvedValue();
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'canvas',
+        'write',
+        '-i',
+        'F0AJ4852CQN',
+        '-m',
+        '追記する内容',
+        '--profile',
+        'work',
+      ]);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
+      expect(SlackApiClient).toHaveBeenCalledWith('work-token');
+    });
+
+    it('should reject an empty markdown message', async () => {
+      const canvasCommand = setupCanvasCommand();
+      canvasCommand.exitOverride();
+
+      const writeCommand = canvasCommand.commands.find((c) => c.name() === 'write')!;
+      writeCommand.exitOverride();
+
+      await expect(
+        writeCommand.parseAsync(['-i', 'F0AJ4852CQN', '-m', ''], { from: 'user' })
+      ).rejects.toThrow('Error: --message is required');
+    });
+
+    it('should reject an invalid position', async () => {
+      const canvasCommand = setupCanvasCommand();
+      canvasCommand.exitOverride();
+
+      const writeCommand = canvasCommand.commands.find((c) => c.name() === 'write')!;
+      writeCommand.exitOverride();
+
+      await expect(
+        writeCommand.parseAsync(
+          ['-i', 'F0AJ4852CQN', '-m', '追記する内容', '--position', 'middle'],
+          { from: 'user' }
+        )
+      ).rejects.toThrow("Error: Invalid position 'middle'. Must be one of: end, start, replace");
+    });
+
+    it('should handle Slack API errors', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.writeCanvas).mockRejectedValue(new Error('canvas_not_found'));
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'canvas',
+        'write',
+        '-i',
+        'invalid-id',
+        '-m',
+        '追記する内容',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.any(String)
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
 });

--- a/tests/commands/canvas.test.ts
+++ b/tests/commands/canvas.test.ts
@@ -516,6 +516,20 @@ describe('canvas command', () => {
       ).rejects.toThrow("Error: Invalid position 'middle'. Must be one of: end, start, replace");
     });
 
+    it('should reject an empty position', async () => {
+      const canvasCommand = setupCanvasCommand();
+      canvasCommand.exitOverride();
+
+      const writeCommand = canvasCommand.commands.find((c) => c.name() === 'write')!;
+      writeCommand.exitOverride();
+
+      await expect(
+        writeCommand.parseAsync(['-i', 'F0AJ4852CQN', '-m', '追記する内容', '--position', ''], {
+          from: 'user',
+        })
+      ).rejects.toThrow("Error: Invalid position ''. Must be one of: end, start, replace");
+    });
+
     it('should handle Slack API errors', async () => {
       vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
         token: 'test-token',

--- a/tests/utils/slack-operations/canvas-operations.test.ts
+++ b/tests/utils/slack-operations/canvas-operations.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CanvasOperations } from '../../../src/utils/slack-operations/canvas-operations';
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: vi.fn().mockImplementation(function () {
+    return {
+      canvases: {
+        edit: vi.fn(),
+        sections: {
+          lookup: vi.fn(),
+        },
+      },
+      files: {
+        list: vi.fn(),
+      },
+    };
+  }),
+  LogLevel: {
+    ERROR: 'error',
+  },
+}));
+
+describe('CanvasOperations', () => {
+  type MockClient = {
+    canvases: {
+      edit: ReturnType<typeof vi.fn>;
+      sections: {
+        lookup: ReturnType<typeof vi.fn>;
+      };
+    };
+  };
+
+  let canvasOps: CanvasOperations;
+  let mockClient: MockClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canvasOps = new CanvasOperations('test-token');
+    mockClient = (canvasOps as unknown as { client: MockClient }).client;
+  });
+
+  describe('writeCanvas', () => {
+    it('should append markdown to the end by default', async () => {
+      mockClient.canvases.edit.mockResolvedValue({ ok: true });
+
+      await canvasOps.writeCanvas('F0AJ4852CQN', '追記する内容', 'end');
+
+      expect(mockClient.canvases.edit).toHaveBeenCalledWith({
+        canvas_id: 'F0AJ4852CQN',
+        changes: [
+          {
+            operation: 'insert_at_end',
+            document_content: {
+              type: 'markdown',
+              markdown: '追記する内容',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should insert markdown at the start', async () => {
+      mockClient.canvases.edit.mockResolvedValue({ ok: true });
+
+      await canvasOps.writeCanvas('F0AJ4852CQN', '先頭に追加', 'start');
+
+      expect(mockClient.canvases.edit).toHaveBeenCalledWith({
+        canvas_id: 'F0AJ4852CQN',
+        changes: [
+          {
+            operation: 'insert_at_start',
+            document_content: {
+              type: 'markdown',
+              markdown: '先頭に追加',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should replace the whole canvas', async () => {
+      mockClient.canvases.edit.mockResolvedValue({ ok: true });
+
+      await canvasOps.writeCanvas('F0AJ4852CQN', '全体を置換', 'replace');
+
+      expect(mockClient.canvases.edit).toHaveBeenCalledWith({
+        canvas_id: 'F0AJ4852CQN',
+        changes: [
+          {
+            operation: 'replace',
+            document_content: {
+              type: 'markdown',
+              markdown: '全体を置換',
+            },
+          },
+        ],
+      });
+    });
+
+    it('should pass markdown through without sanitizing terminal escape sequences', async () => {
+      mockClient.canvases.edit.mockResolvedValue({ ok: true });
+      const markdown = '# Title\n\u001b[31mkeep raw markdown\u001b[0m';
+
+      await canvasOps.writeCanvas('F0AJ4852CQN', markdown, 'end');
+
+      expect(mockClient.canvases.edit).toHaveBeenCalledWith({
+        canvas_id: 'F0AJ4852CQN',
+        changes: [
+          {
+            operation: 'insert_at_end',
+            document_content: {
+              type: 'markdown',
+              markdown,
+            },
+          },
+        ],
+      });
+    });
+
+    it('should throw when edit fails', async () => {
+      mockClient.canvases.edit.mockRejectedValue(new Error('canvas_not_found'));
+
+      await expect(canvasOps.writeCanvas('invalid-id', '追記する内容', 'end')).rejects.toThrow(
+        'canvas_not_found'
+      );
+    });
+  });
+});


### PR DESCRIPTION
# 背景

- `canvas read` と `canvas list` はあるが、既存 Canvas に内容を書き込む CLI インターフェースがなかった。
- Slack API の `canvases.edit` を使い、既存 Canvas への Markdown 追記・先頭挿入・全体置換に対応する。

# 概要

- `slack-cli canvas write` を追加。
- `--position end|start|replace` を追加し、デフォルトは末尾追記にした。
- `replace` は Canvas 全体を置換するため、`--yes` を必須にした。
- 送信する Markdown はターミナル表示用のサニタイズをかけず、そのまま Slack API に渡す。
- `canvases:write` スコープと利用例を README に追記。
- package version を `0.22.0` に更新。

# 関連情報

- Jira issue: なし

# 確認方法

- `npm test -- tests/commands/canvas.test.ts tests/utils/slack-operations/canvas-operations.test.ts`
- `npm run build`
- `npm run check`
- `npm test`
