### PR TITLE
history JSONにfilesを含める

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.22.0",
+      "version": "0.22.1",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/utils/formatters/history-formatters.ts
+++ b/src/utils/formatters/history-formatters.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { Message as SlackMessage } from '../../types/slack';
+import { SlackFile, Message as SlackMessage } from '../../types/slack';
 import { formatTimestampFixed } from '../date-utils';
 import { formatMessageWithMentions, resolveUsername } from '../format-utils';
 import { sanitizeTerminalText } from '../terminal-sanitizer';
@@ -10,6 +10,30 @@ export interface HistoryFormatterOptions {
   messages: SlackMessage[];
   users: Map<string, string>;
   permalinks?: Map<string, string>;
+}
+
+interface HistoryFileOutput {
+  id?: string;
+  name?: string;
+  title?: string;
+  mimetype?: string;
+  filetype?: string;
+  size?: number;
+  url_private?: string;
+  url_private_download?: string;
+}
+
+function formatFile(file: SlackFile): HistoryFileOutput {
+  return {
+    id: file.id,
+    name: file.name,
+    title: file.title,
+    mimetype: file.mimetype,
+    filetype: file.filetype,
+    size: file.size,
+    url_private: file.url_private,
+    url_private_download: file.url_private_download,
+  };
 }
 
 class TableHistoryFormatter extends AbstractFormatter<HistoryFormatterOptions> {
@@ -67,15 +91,20 @@ class JsonHistoryFormatter extends JsonFormatter<HistoryFormatterOptions> {
 
     return {
       channel: channelName,
-      messages: messages.map((message) => ({
-        ts: message.ts,
-        timestamp: formatTimestampFixed(message.ts),
-        user: resolveUsername(message, users),
-        text: message.text || '(no text)',
-        ...(message.thread_ts !== undefined && { thread_ts: message.thread_ts }),
-        ...(message.reply_count !== undefined && { reply_count: message.reply_count }),
-        ...(permalinks?.has(message.ts) && { permalink: permalinks.get(message.ts) }),
-      })),
+      messages: messages.map((message) => {
+        const files = message.files ?? [];
+
+        return {
+          ts: message.ts,
+          timestamp: formatTimestampFixed(message.ts),
+          user: resolveUsername(message, users),
+          text: message.text || '(no text)',
+          ...(message.thread_ts !== undefined && { thread_ts: message.thread_ts }),
+          ...(message.reply_count !== undefined && { reply_count: message.reply_count }),
+          ...(files.length > 0 ? { files: files.map(formatFile) } : {}),
+          ...(permalinks?.has(message.ts) && { permalink: permalinks.get(message.ts) }),
+        };
+      }),
       total: messages.length,
     };
   }

--- a/tests/commands/history.test.ts
+++ b/tests/commands/history.test.ts
@@ -628,6 +628,80 @@ describe('history command', () => {
         expect(normalMessage.reply_count).toBeUndefined();
       });
 
+      it('should include file metadata in JSON format when message has files', async () => {
+        vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+          token: 'test-token',
+          updatedAt: new Date().toISOString(),
+        });
+
+        vi.mocked(mockSlackClient.getHistory).mockResolvedValue({
+          messages: [
+            {
+              type: 'message',
+              text: '',
+              user: 'U123456',
+              ts: '1609459200.000100',
+              files: [
+                {
+                  id: 'F123456',
+                  name: 'screenshot.png',
+                  title: 'Screenshot',
+                  mimetype: 'image/png',
+                  filetype: 'png',
+                  size: 12345,
+                  url_private: 'https://files.slack.com/files-pri/T123-F123456/screenshot.png',
+                  url_private_download:
+                    'https://files.slack.com/files-pri/T123-F123456/download/screenshot.png',
+                },
+              ],
+            },
+            {
+              type: 'message',
+              text: 'No file',
+              user: 'U789012',
+              ts: '1609459100.000100',
+            },
+          ],
+          users: new Map([
+            ['U123456', 'john.doe'],
+            ['U789012', 'jane.smith'],
+          ]),
+        });
+
+        await program.parseAsync([
+          'node',
+          'slack-cli',
+          'history',
+          '-c',
+          'general',
+          '--format',
+          'json',
+        ]);
+
+        const output = JSON.parse(mockConsole.logSpy.mock.calls[0][0]);
+        const fileMessage = output.messages.find((message: { ts: string }) => {
+          return message.ts === '1609459200.000100';
+        });
+        const textOnlyMessage = output.messages.find((message: { ts: string }) => {
+          return message.ts === '1609459100.000100';
+        });
+
+        expect(fileMessage.files).toEqual([
+          {
+            id: 'F123456',
+            name: 'screenshot.png',
+            title: 'Screenshot',
+            mimetype: 'image/png',
+            filetype: 'png',
+            size: 12345,
+            url_private: 'https://files.slack.com/files-pri/T123-F123456/screenshot.png',
+            url_private_download:
+              'https://files.slack.com/files-pri/T123-F123456/download/screenshot.png',
+          },
+        ]);
+        expect(textOnlyMessage.files).toBeUndefined();
+      });
+
       it('should display messages in simple format when --format simple is specified', async () => {
         vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
           token: 'test-token',


### PR DESCRIPTION
# 背景

- `slack-cli history --format json` で Slack メッセージに添付ファイルがあるか判定できるようにしたい。
- 特に画像添付を `mimetype` / `filetype` から機械的に検出できる必要がある。

# 概要

- `history --format json` の各メッセージに、添付ファイルがある場合のみ `files` を出力するように変更。
- `files` は `id`, `name`, `title`, `mimetype`, `filetype`, `size`, `url_private`, `url_private_download` の主要項目に限定。
- ファイルがないメッセージでは従来通り `files` を省略。
- `package.json` / `package-lock.json` を `0.22.1` に patch bump。

# 確認方法

- `npx vitest run tests/commands/history.test.ts`
- `npm run check`
- `npm run build`
- `npm test`
- `npm run test:coverage`
