### PR TITLE
status コマンドを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.1] - 2026-06-12
+
+### Added
+- Add `status keep-alive --detach` and `--pid-file` for CLI-managed background keep-alive processes
+- Add `status stop` to touch stop files, terminate keep-alive PIDs, and clear status as a backstop
+- Check keep-alive stop files at least every 5 seconds even when refresh intervals are longer
+
 ## [0.23.0] - 2026-06-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.0] - 2026-06-12
+
+### Added
+- Add `status` command for Slack `assistant.threads.setStatus`
+- Support `status set`, `status clear`, and `status keep-alive`
+- Support repeated `--loading-message` values, up to Slack's 10 message limit
+
 ## [0.4.4] - 2026-02-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -92,6 +92,31 @@ slack-cli send --user @john -m "Hello via DM!"
 slack-cli send --email john@example.com -m "Hello via DM!"
 ```
 
+### Assistant Thread Status
+
+Slack's `assistant.threads.setStatus` API can show a temporary loading status such as
+`<App name> is thinking...` on a normal channel thread. Since Slack's 2026-03-05
+change, this works with the `chat:write` scope.
+
+```bash
+# Set status on a thread
+slack-cli status set -c channel-name -t 1719207629.000100 --text "Working on it"
+
+# Set status with rotating loading messages
+slack-cli status set -c channel-name -t 1719207629.000100 --text "Working on it" \
+  --loading-message "Reading context" \
+  --loading-message "Calling tools"
+
+# Clear status
+slack-cli status clear -c channel-name -t 1719207629.000100
+
+# Keep status alive until max duration, stop file, or SIGINT/SIGTERM
+slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working on it" \
+  --interval 80 \
+  --max-duration 600 \
+  --stop-file /tmp/slack-cli-status.stop
+```
+
 ### List Channels
 
 ```bash
@@ -415,6 +440,46 @@ printf '%s\n' "$NEW_TOKEN" | slack-cli config set --token-stdin
 | --at      |       | Schedule time (Unix seconds or ISO 8601) |
 | --after   |       | Schedule message after N minutes         |
 
+### status command
+
+Subcommands: `set`, `clear`, `keep-alive`
+
+#### status set
+
+| Option            | Short | Description                                      |
+| ----------------- | ----- | ------------------------------------------------ |
+| --channel         | -c    | Target channel name or ID (required)             |
+| --thread          | -t    | Thread parent timestamp (required)               |
+| --text            |       | Status text (required)                           |
+| --loading-message |       | Optional loading message; repeatable up to 10    |
+| --profile         |       | Use specific workspace profile                   |
+
+#### status clear
+
+| Option    | Short | Description                          |
+| --------- | ----- | ------------------------------------ |
+| --channel | -c    | Target channel name or ID (required) |
+| --thread  | -t    | Thread parent timestamp (required)   |
+| --profile |       | Use specific workspace profile       |
+
+#### status keep-alive
+
+Refreshes status immediately and then every `--interval` seconds because Slack clears assistant
+thread status after roughly two minutes. It stops when `--max-duration` elapses, `--stop-file`
+exists at a tick, or SIGINT/SIGTERM is received. Every exit path sends a final clear request;
+clear failures are ignored.
+
+| Option            | Short | Description                                           |
+| ----------------- | ----- | ----------------------------------------------------- |
+| --channel         | -c    | Target channel name or ID (required)                  |
+| --thread          | -t    | Thread parent timestamp (required)                    |
+| --text            |       | Status text (required)                                |
+| --interval        |       | Refresh interval in seconds (default: 80)             |
+| --max-duration    |       | Maximum duration in seconds (default: 600)            |
+| --stop-file       |       | Stop when this path exists                            |
+| --loading-message |       | Optional loading message; repeatable up to 10         |
+| --profile         |       | Use specific workspace profile                        |
+
 ### channels command
 
 | Option             | Short | Description                                                    |
@@ -605,7 +670,7 @@ Writes markdown to an existing Canvas. It does not create a new Canvas.
 
 Your Slack API token needs the following scopes:
 
-- `chat:write` - Send and edit messages
+- `chat:write` - Send and edit messages; also required for `status` commands using Slack's `assistant.threads.setStatus` API
 - `channels:read` - List public channels and get channel info
 - `channels:write` - Set topic/purpose for public channels
 - `groups:read` - List private channels and get channel info

--- a/README.md
+++ b/README.md
@@ -115,6 +115,19 @@ slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working
   --interval 80 \
   --max-duration 600 \
   --stop-file /tmp/slack-cli-status.stop
+
+# Run keep-alive in the background and record its PID
+slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working on it" \
+  --interval 80 \
+  --max-duration 600 \
+  --stop-file /tmp/slack-cli-status.stop \
+  --detach \
+  --pid-file /tmp/slack-cli-status.pid
+
+# Stop a background keep-alive process and clear status as a backstop
+slack-cli status stop -c channel-name -t 1719207629.000100 \
+  --stop-file /tmp/slack-cli-status.stop \
+  --pid-file /tmp/slack-cli-status.pid
 ```
 
 ### List Channels
@@ -442,7 +455,7 @@ printf '%s\n' "$NEW_TOKEN" | slack-cli config set --token-stdin
 
 ### status command
 
-Subcommands: `set`, `clear`, `keep-alive`
+Subcommands: `set`, `clear`, `keep-alive`, `stop`
 
 #### status set
 
@@ -466,8 +479,13 @@ Subcommands: `set`, `clear`, `keep-alive`
 
 Refreshes status immediately and then every `--interval` seconds because Slack clears assistant
 thread status after roughly two minutes. It stops when `--max-duration` elapses, `--stop-file`
-exists at a tick, or SIGINT/SIGTERM is received. Every exit path sends a final clear request;
-clear failures are ignored.
+exists, or SIGINT/SIGTERM is received. Stop-file checks run at least every 5 seconds even when
+the refresh interval is longer. Every exit path sends a final clear request; clear failures are
+ignored.
+
+With `--detach`, the CLI starts the same keep-alive command in a detached child process without
+`--detach`, writes the child PID to `--pid-file`, and exits immediately. Without `--detach`,
+`--pid-file` writes the foreground process PID and is removed when keep-alive exits.
 
 | Option            | Short | Description                                           |
 | ----------------- | ----- | ----------------------------------------------------- |
@@ -477,8 +495,25 @@ clear failures are ignored.
 | --interval        |       | Refresh interval in seconds (default: 80)             |
 | --max-duration    |       | Maximum duration in seconds (default: 600)            |
 | --stop-file       |       | Stop when this path exists                            |
+| --detach          |       | Run keep-alive in a detached background process       |
+| --pid-file        |       | Write the keep-alive process ID to this file          |
 | --loading-message |       | Optional loading message; repeatable up to 10         |
 | --profile         |       | Use specific workspace profile                        |
+
+#### status stop
+
+Creates the optional stop-file, terminates the optional pid-file process with SIGTERM and then
+SIGKILL after `--timeout`, removes the pid-file, and finally clears status as a backstop. Missing
+files, dead processes, kill failures, and clear failures only print warnings; the command exits 0.
+
+| Option      | Short | Description                                   |
+| ----------- | ----- | --------------------------------------------- |
+| --channel   | -c    | Target channel name or ID (required)          |
+| --thread    | -t    | Thread parent timestamp (required)            |
+| --stop-file |       | Create this stop file before stopping         |
+| --pid-file  |       | Read and stop the process ID from this file   |
+| --timeout   |       | Seconds before SIGKILL after SIGTERM (default: 5) |
+| --profile   |       | Use specific workspace profile                |
 
 ### channels command
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.22.1",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,295 @@
+import chalk from 'chalk';
+import { Command } from 'commander';
+import * as fs from 'fs';
+import type {
+  StatusClearOptions,
+  StatusKeepAliveOptions,
+  StatusSetOptions,
+} from '../types/commands';
+import { createSlackClient } from '../utils/client-factory';
+import { wrapCommand } from '../utils/command-wrapper';
+import { extractErrorMessage } from '../utils/error-utils';
+import { parseProfile } from '../utils/option-parsers';
+import { createValidationHook, formatValidators } from '../utils/validators';
+
+const DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS = 80;
+const DEFAULT_KEEP_ALIVE_MAX_DURATION_SECONDS = 600;
+const MAX_LOADING_MESSAGES = 10;
+
+type StatusCommandOptions = {
+  channel?: string;
+  thread?: string;
+  text?: string;
+  interval?: string;
+  maxDuration?: string;
+  loadingMessage?: string[];
+};
+
+function collectLoadingMessage(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+function validateStatusBase(options: StatusCommandOptions): string | null {
+  if (!options.channel) {
+    return '--channel is required';
+  }
+
+  if (!options.thread) {
+    return '--thread is required';
+  }
+
+  return formatValidators.threadTimestamp(options.thread);
+}
+
+function validateStatusText(options: StatusCommandOptions): string | null {
+  if (options.text === undefined || options.text === '') {
+    return '--text is required';
+  }
+
+  return null;
+}
+
+function validateLoadingMessages(options: StatusCommandOptions): string | null {
+  if ((options.loadingMessage?.length ?? 0) > MAX_LOADING_MESSAGES) {
+    return '--loading-message can be specified at most 10 times';
+  }
+
+  return null;
+}
+
+function validatePositiveIntegerOption(
+  options: StatusCommandOptions,
+  optionName: 'interval' | 'maxDuration',
+  label: string
+): string | null {
+  const value = options[optionName];
+  if (value === undefined) {
+    return null;
+  }
+
+  if (!/^\d+$/.test(value)) {
+    return `${label} must be a positive integer`;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return `${label} must be a positive integer`;
+  }
+
+  return null;
+}
+
+function parsePositiveSeconds(value: string | undefined, defaultValue: number): number {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  return Number.parseInt(value, 10);
+}
+
+function createInterruptibleDelay(
+  ms: number,
+  isStopped: () => boolean,
+  registerWake: (wake: (() => void) | undefined) => void
+): Promise<void> {
+  if (ms <= 0 || isStopped()) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      registerWake(undefined);
+      resolve();
+    }, ms);
+
+    registerWake(() => {
+      clearTimeout(timeout);
+      registerWake(undefined);
+      resolve();
+    });
+  });
+}
+
+async function clearStatusIgnoringErrors(
+  client: Awaited<ReturnType<typeof createSlackClient>>,
+  channel: string,
+  threadTs: string
+): Promise<void> {
+  try {
+    await client.clearAssistantThreadStatus(channel, threadTs);
+  } catch {
+    // keep-alive cleanup should not turn an otherwise successful shutdown into a failure.
+  }
+}
+
+async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
+  const intervalSeconds = parsePositiveSeconds(
+    options.interval,
+    DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS
+  );
+  const maxDurationSeconds = parsePositiveSeconds(
+    options.maxDuration,
+    DEFAULT_KEEP_ALIVE_MAX_DURATION_SECONDS
+  );
+  const intervalMs = intervalSeconds * 1000;
+  const maxDurationMs = maxDurationSeconds * 1000;
+  const profile = parseProfile(options.profile);
+  const client = await createSlackClient(profile);
+  const startedAt = Date.now();
+  let stopRequested = false;
+  let wakeDelay: (() => void) | undefined;
+
+  const requestStop = () => {
+    stopRequested = true;
+    wakeDelay?.();
+  };
+
+  process.once('SIGINT', requestStop);
+  process.once('SIGTERM', requestStop);
+
+  try {
+    await client.setAssistantThreadStatus({
+      channel: options.channel,
+      threadTs: options.thread,
+      status: options.text,
+      loadingMessages: options.loadingMessage,
+    });
+
+    while (!stopRequested) {
+      const elapsedMs = Date.now() - startedAt;
+      const remainingMs = maxDurationMs - elapsedMs;
+      if (remainingMs <= 0) {
+        break;
+      }
+
+      await createInterruptibleDelay(
+        Math.min(intervalMs, remainingMs),
+        () => stopRequested,
+        (wake) => {
+          wakeDelay = wake;
+        }
+      );
+
+      if (stopRequested) {
+        break;
+      }
+
+      if (options.stopFile && fs.existsSync(options.stopFile)) {
+        break;
+      }
+
+      if (Date.now() - startedAt >= maxDurationMs) {
+        break;
+      }
+
+      try {
+        await client.setAssistantThreadStatus({
+          channel: options.channel,
+          threadTs: options.thread,
+          status: options.text,
+          loadingMessages: options.loadingMessage,
+        });
+      } catch (error) {
+        console.error(chalk.yellow('Warning:'), extractErrorMessage(error));
+      }
+    }
+  } finally {
+    process.off('SIGINT', requestStop);
+    process.off('SIGTERM', requestStop);
+    await clearStatusIgnoringErrors(client, options.channel, options.thread);
+  }
+}
+
+export function setupStatusCommand(): Command {
+  const statusCommand = new Command('status').description('Manage Slack assistant thread status');
+
+  const setCommand = new Command('set')
+    .description('Set assistant status for a thread')
+    .option('-c, --channel <channel>', 'Target channel name or ID')
+    .option('-t, --thread <thread>', 'Thread parent timestamp')
+    .requiredOption('--text <text>', 'Status text')
+    .option(
+      '--loading-message <message>',
+      'Loading message shown by Slack; can be specified up to 10 times',
+      collectLoadingMessage,
+      []
+    )
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook(
+      'preAction',
+      createValidationHook([validateStatusBase, validateStatusText, validateLoadingMessages])
+    )
+    .action(
+      wrapCommand(async (options: StatusSetOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+        await client.setAssistantThreadStatus({
+          channel: options.channel,
+          threadTs: options.thread,
+          status: options.text,
+          loadingMessages: options.loadingMessage,
+        });
+        console.log(
+          chalk.green(`✓ Status set for thread ${options.thread} in #${options.channel}`)
+        );
+      })
+    );
+
+  const clearCommand = new Command('clear')
+    .description('Clear assistant status for a thread')
+    .option('-c, --channel <channel>', 'Target channel name or ID')
+    .option('-t, --thread <thread>', 'Thread parent timestamp')
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook('preAction', createValidationHook([validateStatusBase]))
+    .action(
+      wrapCommand(async (options: StatusClearOptions) => {
+        const profile = parseProfile(options.profile);
+        const client = await createSlackClient(profile);
+        await client.clearAssistantThreadStatus(options.channel, options.thread);
+        console.log(
+          chalk.green(`✓ Status cleared for thread ${options.thread} in #${options.channel}`)
+        );
+      })
+    );
+
+  const keepAliveCommand = new Command('keep-alive')
+    .description('Refresh assistant status until max duration, stop file, or signal')
+    .option('-c, --channel <channel>', 'Target channel name or ID')
+    .option('-t, --thread <thread>', 'Thread parent timestamp')
+    .requiredOption('--text <text>', 'Status text')
+    .option(
+      '--interval <seconds>',
+      'Seconds between status refreshes',
+      DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS.toString()
+    )
+    .option(
+      '--max-duration <seconds>',
+      'Maximum keep-alive duration in seconds',
+      DEFAULT_KEEP_ALIVE_MAX_DURATION_SECONDS.toString()
+    )
+    .option('--stop-file <path>', 'Stop when this file exists')
+    .option(
+      '--loading-message <message>',
+      'Loading message shown by Slack; can be specified up to 10 times',
+      collectLoadingMessage,
+      []
+    )
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook(
+      'preAction',
+      createValidationHook([
+        validateStatusBase,
+        validateStatusText,
+        validateLoadingMessages,
+        (options) => validatePositiveIntegerOption(options, 'interval', '--interval'),
+        (options) => validatePositiveIntegerOption(options, 'maxDuration', '--max-duration'),
+      ])
+    )
+    .action(wrapCommand(runKeepAlive));
+
+  statusCommand.addCommand(setCommand);
+  statusCommand.addCommand(clearCommand);
+  statusCommand.addCommand(keepAliveCommand);
+
+  return statusCommand;
+}

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,10 +1,13 @@
 import chalk from 'chalk';
+import { spawn } from 'child_process';
 import { Command } from 'commander';
 import * as fs from 'fs';
+import * as path from 'path';
 import type {
   StatusClearOptions,
   StatusKeepAliveOptions,
   StatusSetOptions,
+  StatusStopOptions,
 } from '../types/commands';
 import { createSlackClient } from '../utils/client-factory';
 import { wrapCommand } from '../utils/command-wrapper';
@@ -14,6 +17,9 @@ import { createValidationHook, formatValidators } from '../utils/validators';
 
 const DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS = 80;
 const DEFAULT_KEEP_ALIVE_MAX_DURATION_SECONDS = 600;
+const DEFAULT_STOP_TIMEOUT_SECONDS = 5;
+const STOP_FILE_POLL_INTERVAL_MS = 5000;
+const STOP_PROCESS_POLL_INTERVAL_MS = 100;
 const MAX_LOADING_MESSAGES = 10;
 
 type StatusCommandOptions = {
@@ -22,6 +28,9 @@ type StatusCommandOptions = {
   text?: string;
   interval?: string;
   maxDuration?: string;
+  timeout?: string;
+  detach?: boolean;
+  pidFile?: string;
   loadingMessage?: string[];
 };
 
@@ -59,7 +68,7 @@ function validateLoadingMessages(options: StatusCommandOptions): string | null {
 
 function validatePositiveIntegerOption(
   options: StatusCommandOptions,
-  optionName: 'interval' | 'maxDuration',
+  optionName: 'interval' | 'maxDuration' | 'timeout',
   label: string
 ): string | null {
   const value = options[optionName];
@@ -74,6 +83,14 @@ function validatePositiveIntegerOption(
   const parsed = Number.parseInt(value, 10);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     return `${label} must be a positive integer`;
+  }
+
+  return null;
+}
+
+function validateDetachOptions(options: StatusCommandOptions): string | null {
+  if (options.detach && !options.pidFile) {
+    return '--pid-file is required when --detach is used';
   }
 
   return null;
@@ -110,6 +127,31 @@ function createInterruptibleDelay(
   });
 }
 
+async function createStopFileAwareDelay(
+  ms: number,
+  isStopped: () => boolean,
+  registerWake: (wake: (() => void) | undefined) => void,
+  stopFile?: string
+): Promise<void> {
+  const deadline = Date.now() + ms;
+
+  while (!isStopped() && Date.now() < deadline) {
+    if (stopFile && fs.existsSync(stopFile)) {
+      return;
+    }
+
+    await createInterruptibleDelay(
+      Math.min(STOP_FILE_POLL_INTERVAL_MS, deadline - Date.now()),
+      isStopped,
+      registerWake
+    );
+  }
+}
+
+function warn(message: string): void {
+  console.error(chalk.yellow('Warning:'), message);
+}
+
 async function clearStatusIgnoringErrors(
   client: Awaited<ReturnType<typeof createSlackClient>>,
   channel: string,
@@ -122,7 +164,115 @@ async function clearStatusIgnoringErrors(
   }
 }
 
+function removeFileIgnoringErrors(filePath: string | undefined): void {
+  if (!filePath) {
+    return;
+  }
+
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Cleanup is best-effort for lifecycle files.
+  }
+}
+
+function writePidFile(pidFile: string, pid: number): void {
+  const directory = path.dirname(pidFile);
+  if (directory && directory !== '.') {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+
+  fs.writeFileSync(pidFile, `${pid}\n`);
+}
+
+function createDetachedArgs(): string[] {
+  return process.argv.slice(1).filter((arg) => arg !== '--detach');
+}
+
+function runDetachedKeepAlive(options: StatusKeepAliveOptions): void {
+  const child = spawn(process.execPath, createDetachedArgs(), {
+    detached: true,
+    stdio: 'ignore',
+  });
+
+  if (child.pid === undefined) {
+    throw new Error('Failed to start detached keep-alive process');
+  }
+
+  writePidFile(options.pidFile!, child.pid);
+  child.unref();
+}
+
+function touchStopFile(stopFile: string): void {
+  const directory = path.dirname(stopFile);
+  if (directory && directory !== '.') {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+
+  const handle = fs.openSync(stopFile, 'a');
+  fs.closeSync(handle);
+  fs.utimesSync(stopFile, new Date(), new Date());
+}
+
+function parsePid(pidFile: string): number | undefined {
+  const content = fs.readFileSync(pidFile, 'utf8').trim();
+  if (!/^\d+$/.test(content)) {
+    return undefined;
+  }
+
+  const pid = Number.parseInt(content, 10);
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return undefined;
+  }
+
+  return pid;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error) {
+      return (error as { code?: string }).code === 'EPERM';
+    }
+
+    return false;
+  }
+}
+
+function sendSignal(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch (error) {
+    warn(`Failed to send ${signal} to process ${pid}: ${extractErrorMessage(error)}`);
+    return false;
+  }
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) {
+      return true;
+    }
+
+    await new Promise((resolve) =>
+      setTimeout(resolve, Math.min(STOP_PROCESS_POLL_INTERVAL_MS, deadline - Date.now()))
+    );
+  }
+
+  return !isProcessAlive(pid);
+}
+
 async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
+  if (options.detach) {
+    runDetachedKeepAlive(options);
+    return;
+  }
+
   const intervalSeconds = parsePositiveSeconds(
     options.interval,
     DEFAULT_KEEP_ALIVE_INTERVAL_SECONDS
@@ -148,6 +298,10 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   process.once('SIGTERM', requestStop);
 
   try {
+    if (options.pidFile) {
+      writePidFile(options.pidFile, process.pid);
+    }
+
     await client.setAssistantThreadStatus({
       channel: options.channel,
       threadTs: options.thread,
@@ -162,12 +316,13 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
         break;
       }
 
-      await createInterruptibleDelay(
+      await createStopFileAwareDelay(
         Math.min(intervalMs, remainingMs),
         () => stopRequested,
         (wake) => {
           wakeDelay = wake;
-        }
+        },
+        options.stopFile
       );
 
       if (stopRequested) {
@@ -197,7 +352,68 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
     process.off('SIGINT', requestStop);
     process.off('SIGTERM', requestStop);
     await clearStatusIgnoringErrors(client, options.channel, options.thread);
+    removeFileIgnoringErrors(options.pidFile);
   }
+}
+
+async function clearStatusWithWarning(options: StatusStopOptions): Promise<void> {
+  try {
+    const profile = parseProfile(options.profile);
+    const client = await createSlackClient(profile);
+    await client.clearAssistantThreadStatus(options.channel, options.thread);
+  } catch (error) {
+    warn(`Failed to clear status: ${extractErrorMessage(error)}`);
+  }
+}
+
+async function stopProcessFromPidFile(pidFile: string, timeoutMs: number): Promise<void> {
+  let pid: number | undefined;
+
+  try {
+    pid = parsePid(pidFile);
+  } catch (error) {
+    warn(`Failed to read pid-file ${pidFile}: ${extractErrorMessage(error)}`);
+    removeFileIgnoringErrors(pidFile);
+    return;
+  }
+
+  if (pid === undefined) {
+    warn(`Invalid pid-file ${pidFile}`);
+    removeFileIgnoringErrors(pidFile);
+    return;
+  }
+
+  if (!isProcessAlive(pid)) {
+    warn(`Process ${pid} is not running`);
+    removeFileIgnoringErrors(pidFile);
+    return;
+  }
+
+  if (sendSignal(pid, 'SIGTERM')) {
+    const exited = await waitForProcessExit(pid, timeoutMs);
+    if (!exited && isProcessAlive(pid)) {
+      sendSignal(pid, 'SIGKILL');
+    }
+  }
+
+  removeFileIgnoringErrors(pidFile);
+}
+
+async function runStop(options: StatusStopOptions): Promise<void> {
+  if (options.stopFile) {
+    try {
+      touchStopFile(options.stopFile);
+    } catch (error) {
+      warn(`Failed to create stop-file ${options.stopFile}: ${extractErrorMessage(error)}`);
+    }
+  }
+
+  if (options.pidFile) {
+    const timeoutSeconds = parsePositiveSeconds(options.timeout, DEFAULT_STOP_TIMEOUT_SECONDS);
+    await stopProcessFromPidFile(options.pidFile, timeoutSeconds * 1000);
+  }
+
+  await clearStatusWithWarning(options);
 }
 
 export function setupStatusCommand(): Command {
@@ -283,13 +499,38 @@ export function setupStatusCommand(): Command {
         validateLoadingMessages,
         (options) => validatePositiveIntegerOption(options, 'interval', '--interval'),
         (options) => validatePositiveIntegerOption(options, 'maxDuration', '--max-duration'),
+        validateDetachOptions,
       ])
     )
+    .option('--detach', 'Run keep-alive in a detached background process')
+    .option('--pid-file <path>', 'Write the keep-alive process ID to this file')
     .action(wrapCommand(runKeepAlive));
+
+  const stopCommand = new Command('stop')
+    .description('Stop a keep-alive process and clear assistant status')
+    .option('-c, --channel <channel>', 'Target channel name or ID')
+    .option('-t, --thread <thread>', 'Thread parent timestamp')
+    .option('--stop-file <path>', 'Create this stop file before stopping')
+    .option('--pid-file <path>', 'Read and stop the process ID from this file')
+    .option(
+      '--timeout <seconds>',
+      'Seconds to wait after SIGTERM before SIGKILL',
+      DEFAULT_STOP_TIMEOUT_SECONDS.toString()
+    )
+    .option('--profile <profile>', 'Use specific workspace profile')
+    .hook(
+      'preAction',
+      createValidationHook([
+        validateStatusBase,
+        (options) => validatePositiveIntegerOption(options, 'timeout', '--timeout'),
+      ])
+    )
+    .action(wrapCommand(runStop));
 
   statusCommand.addCommand(setCommand);
   statusCommand.addCommand(clearCommand);
   statusCommand.addCommand(keepAliveCommand);
+  statusCommand.addCommand(stopCommand);
 
   return statusCommand;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { setupScheduledCommand } from './commands/scheduled';
 import { setupSearchCommand } from './commands/search';
 import { setupSendCommand } from './commands/send';
 import { setupSendEphemeralCommand } from './commands/send-ephemeral';
+import { setupStatusCommand } from './commands/status';
 import { setupUnreadCommand } from './commands/unread';
 import { setupUploadCommand } from './commands/upload';
 import { setupUsersCommand } from './commands/users';
@@ -70,6 +71,7 @@ export function createProgram(): Command {
   program.addCommand(setupReminderCommand());
   program.addCommand(setupBookmarkCommand());
   program.addCommand(setupCanvasCommand());
+  program.addCommand(setupStatusCommand());
 
   return program;
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -27,6 +27,31 @@ export interface SendOptions {
   profile?: string;
 }
 
+export interface StatusSetOptions {
+  channel: string;
+  thread: string;
+  text: string;
+  loadingMessage?: string[];
+  profile?: string;
+}
+
+export interface StatusClearOptions {
+  channel: string;
+  thread: string;
+  profile?: string;
+}
+
+export interface StatusKeepAliveOptions {
+  channel: string;
+  thread: string;
+  text: string;
+  interval?: string;
+  maxDuration?: string;
+  stopFile?: string;
+  loadingMessage?: string[];
+  profile?: string;
+}
+
 export interface ScheduledListOptions {
   channel?: string;
   limit?: string;

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -48,7 +48,18 @@ export interface StatusKeepAliveOptions {
   interval?: string;
   maxDuration?: string;
   stopFile?: string;
+  detach?: boolean;
+  pidFile?: string;
   loadingMessage?: string[];
+  profile?: string;
+}
+
+export interface StatusStopOptions {
+  channel: string;
+  thread: string;
+  stopFile?: string;
+  pidFile?: string;
+  timeout?: string;
   profile?: string;
 }
 

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -26,6 +26,11 @@ import type {
   StarListResult,
   UserPresence,
 } from '../types/slack';
+import {
+  AssistantOperations,
+  type AssistantThreadStatusOptions,
+  type AssistantThreadStatusResponse,
+} from './slack-operations/assistant-operations';
 import { createSlackClientContext } from './slack-operations/base-client';
 import { CanvasOperations } from './slack-operations/canvas-operations';
 import { ChannelOperations } from './slack-operations/channel-operations';
@@ -54,6 +59,7 @@ export class SlackApiClient {
   private reminderOps: ReminderOperations;
   private starOps: StarOperations;
   private canvasOps: CanvasOperations;
+  private assistantOps: AssistantOperations;
 
   constructor(token: string) {
     const sharedContext = createSlackClientContext(token);
@@ -67,6 +73,7 @@ export class SlackApiClient {
     this.reminderOps = new ReminderOperations(sharedContext);
     this.starOps = new StarOperations(sharedContext);
     this.canvasOps = new CanvasOperations(sharedContext, this.channelOps);
+    this.assistantOps = new AssistantOperations(sharedContext, this.channelOps);
   }
 
   async sendMessage(
@@ -257,6 +264,19 @@ export class SlackApiClient {
 
   async listReminders(): Promise<Reminder[]> {
     return this.reminderOps.listReminders();
+  }
+
+  async setAssistantThreadStatus(
+    options: AssistantThreadStatusOptions
+  ): Promise<AssistantThreadStatusResponse> {
+    return this.assistantOps.setThreadStatus(options);
+  }
+
+  async clearAssistantThreadStatus(
+    channel: string,
+    threadTs: string
+  ): Promise<AssistantThreadStatusResponse> {
+    return this.assistantOps.clearThreadStatus(channel, threadTs);
   }
 
   async deleteReminder(reminderId: string): Promise<void> {

--- a/src/utils/slack-operations/assistant-operations.ts
+++ b/src/utils/slack-operations/assistant-operations.ts
@@ -1,0 +1,78 @@
+import { BaseSlackClient, type SlackClientDependency } from './base-client';
+import { ChannelOperations } from './channel-operations';
+
+export interface AssistantThreadStatusOptions {
+  channel: string;
+  threadTs: string;
+  status: string;
+  loadingMessages?: string[];
+}
+
+export interface AssistantThreadStatusResponse {
+  ok: boolean;
+  [key: string]: unknown;
+}
+
+interface AssistantThreadsSetStatusArguments {
+  channel_id: string;
+  thread_ts: string;
+  status: string;
+  loading_messages?: string[];
+}
+
+type AssistantCapableClient = {
+  assistant?: {
+    threads?: {
+      setStatus?: (
+        options: AssistantThreadsSetStatusArguments
+      ) => Promise<AssistantThreadStatusResponse>;
+    };
+  };
+  apiCall: (
+    method: string,
+    options?: Record<string, unknown>
+  ) => Promise<AssistantThreadStatusResponse>;
+};
+
+export class AssistantOperations extends BaseSlackClient {
+  private channelOps: ChannelOperations;
+
+  constructor(dependency: SlackClientDependency, channelOps?: ChannelOperations) {
+    super(dependency);
+    this.channelOps = channelOps ?? new ChannelOperations(dependency);
+  }
+
+  async setThreadStatus(
+    options: AssistantThreadStatusOptions
+  ): Promise<AssistantThreadStatusResponse> {
+    const channelId = await this.channelOps.resolveChannelId(options.channel);
+    const params: AssistantThreadsSetStatusArguments = {
+      channel_id: channelId,
+      thread_ts: options.threadTs,
+      status: options.status,
+    };
+
+    if (options.loadingMessages && options.loadingMessages.length > 0) {
+      params.loading_messages = options.loadingMessages;
+    }
+
+    const client = this.client as unknown as AssistantCapableClient;
+    const setStatus = client.assistant?.threads?.setStatus;
+    if (setStatus) {
+      return await setStatus(params);
+    }
+
+    return await client.apiCall('assistant.threads.setStatus', { ...params });
+  }
+
+  async clearThreadStatus(
+    channel: string,
+    threadTs: string
+  ): Promise<AssistantThreadStatusResponse> {
+    return await this.setThreadStatus({
+      channel,
+      threadTs,
+      status: '',
+    });
+  }
+}

--- a/src/utils/slack-operations/index.ts
+++ b/src/utils/slack-operations/index.ts
@@ -1,3 +1,4 @@
+export { AssistantOperations } from './assistant-operations';
 export { BaseSlackClient } from './base-client';
 export { ChannelOperations } from './channel-operations';
 export { MessageOperations } from './message-operations';

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -1,0 +1,359 @@
+import * as fs from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { setupStatusCommand } from '../../src/commands/status';
+import { ProfileConfigManager } from '../../src/utils/profile-config';
+import { SlackApiClient } from '../../src/utils/slack-api-client';
+import { createTestProgram, restoreMocks, setupMockConsole } from '../test-utils';
+
+vi.mock('../../src/utils/slack-api-client');
+vi.mock('../../src/utils/profile-config');
+
+describe('status command', () => {
+  let program: ReturnType<typeof createTestProgram>;
+  let mockSlackClient: SlackApiClient;
+  let mockConfigManager: ProfileConfigManager;
+  let mockConsole: ReturnType<typeof setupMockConsole>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = new ProfileConfigManager();
+    vi.mocked(ProfileConfigManager).mockImplementation(function () {
+      return mockConfigManager;
+    });
+
+    mockSlackClient = new SlackApiClient('test-token');
+    vi.mocked(SlackApiClient).mockImplementation(function () {
+      return mockSlackClient;
+    });
+
+    mockConsole = setupMockConsole();
+    program = createTestProgram();
+    program.addCommand(setupStatusCommand());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    restoreMocks();
+  });
+
+  function mockConfiguredClient(): void {
+    vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+      token: 'test-token',
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  describe('set subcommand', () => {
+    it('should set assistant thread status with loading messages', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'set',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--loading-message',
+        'Reading context',
+        '--loading-message',
+        'Calling Slack',
+      ]);
+
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['Reading context', 'Calling Slack'],
+      });
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Status set'));
+    });
+
+    it('should report API errors and exit non-zero', async () => {
+      mockConfiguredClient();
+      const error = new Error('missing_scope');
+      Object.assign(error, { data: { error: 'missing_scope', needed: 'chat:write' } });
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockRejectedValue(error);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'set',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('missing_scope')
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('clear subcommand', () => {
+    it('should clear assistant thread status', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'clear',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+      ]);
+
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456'
+      );
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('Status cleared'));
+    });
+  });
+
+  describe('keep-alive subcommand', () => {
+    it('should refresh until max-duration and then clear status', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '12',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(3);
+
+      await vi.advanceTimersByTimeAsync(2000);
+      await keepAlivePromise;
+
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456'
+      );
+    });
+
+    it('should stop when stop-file exists and then clear status', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const stopFile = `/tmp/slack-cli-stop-${process.pid}-${Date.now()}`;
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '60',
+        '--stop-file',
+        stopFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      fs.writeFileSync(stopFile, '');
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+      fs.unlinkSync(stopFile);
+
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456'
+      );
+    });
+
+    it('should stop on SIGINT and then clear status', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '80',
+        '--max-duration',
+        '600',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      process.emit('SIGINT');
+      await keepAlivePromise;
+
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456'
+      );
+    });
+
+    it('should warn and continue on transient refresh failures', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus)
+        .mockResolvedValueOnce({ ok: true })
+        .mockRejectedValueOnce(new Error('timeout'))
+        .mockResolvedValueOnce({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '11',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(11000);
+      await keepAlivePromise;
+
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(3);
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        'timeout'
+      );
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456'
+      );
+    });
+
+    it('should ignore clear failures during shutdown', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockRejectedValue(
+        new Error('clear failed')
+      );
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+
+      expect(mockConsole.exitSpy).not.toHaveBeenCalled();
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('should reject more than 10 loading messages', async () => {
+      const statusCommand = setupStatusCommand();
+      statusCommand.exitOverride();
+      const setCommand = statusCommand.commands.find((command) => command.name() === 'set')!;
+      setCommand.exitOverride();
+      const args = [
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        ...Array.from({ length: 11 }, (_, index) => ['--loading-message', `msg-${index}`]).flat(),
+      ];
+
+      await expect(setCommand.parseAsync(args, { from: 'user' })).rejects.toThrow(
+        '--loading-message can be specified at most 10 times'
+      );
+    });
+
+    it('should reject invalid keep-alive interval', async () => {
+      const statusCommand = setupStatusCommand();
+      statusCommand.exitOverride();
+      const keepAliveCommand = statusCommand.commands.find(
+        (command) => command.name() === 'keep-alive'
+      )!;
+      keepAliveCommand.exitOverride();
+
+      await expect(
+        keepAliveCommand.parseAsync(
+          ['-c', 'general', '-t', '1234567890.123456', '--text', 'Working', '--interval', '0'],
+          { from: 'user' }
+        )
+      ).rejects.toThrow('--interval must be a positive integer');
+    });
+  });
+});

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -1,10 +1,15 @@
+import { spawn } from 'child_process';
 import * as fs from 'fs';
+import * as path from 'path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { setupStatusCommand } from '../../src/commands/status';
 import { ProfileConfigManager } from '../../src/utils/profile-config';
 import { SlackApiClient } from '../../src/utils/slack-api-client';
 import { createTestProgram, restoreMocks, setupMockConsole } from '../test-utils';
 
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
 vi.mock('../../src/utils/slack-api-client');
 vi.mock('../../src/utils/profile-config');
 
@@ -42,6 +47,16 @@ describe('status command', () => {
       token: 'test-token',
       updatedAt: new Date().toISOString(),
     });
+  }
+
+  function tempPath(name: string): string {
+    return path.join('/tmp', `slack-cli-${name}-${process.pid}-${Date.now()}`);
+  }
+
+  function notRunningError(): Error & { code: string } {
+    const error = new Error('not running') as Error & { code: string };
+    error.code = 'ESRCH';
+    return error;
   }
 
   describe('set subcommand', () => {
@@ -169,13 +184,13 @@ describe('status command', () => {
       );
     });
 
-    it('should stop when stop-file exists and then clear status', async () => {
+    it('should detect stop-file within five seconds and then clear status', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
       mockConfiguredClient();
       vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
       vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
-      const stopFile = `/tmp/slack-cli-stop-${process.pid}-${Date.now()}`;
+      const stopFile = tempPath('stop');
 
       const keepAlivePromise = program.parseAsync([
         'node',
@@ -189,7 +204,7 @@ describe('status command', () => {
         '--text',
         'Working',
         '--interval',
-        '5',
+        '80',
         '--max-duration',
         '60',
         '--stop-file',
@@ -207,6 +222,106 @@ describe('status command', () => {
         'general',
         '1234567890.123456'
       );
+    });
+
+    it('should spawn a detached copy without --detach and write child pid', async () => {
+      const pidFile = tempPath('detached.pid');
+      const originalArgv = process.argv;
+      const unref = vi.fn();
+      vi.mocked(spawn).mockReturnValue({
+        pid: 4321,
+        unref,
+      } as ReturnType<typeof spawn>);
+      process.argv = [
+        'node',
+        '/repo/dist/index.js',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '80',
+        '--max-duration',
+        '600',
+        '--detach',
+        '--pid-file',
+        pidFile,
+      ];
+
+      try {
+        await program.parseAsync(process.argv);
+      } finally {
+        process.argv = originalArgv;
+      }
+
+      expect(spawn).toHaveBeenCalledWith(
+        process.execPath,
+        [
+          '/repo/dist/index.js',
+          'status',
+          'keep-alive',
+          '-c',
+          'general',
+          '-t',
+          '1234567890.123456',
+          '--text',
+          'Working',
+          '--interval',
+          '80',
+          '--max-duration',
+          '600',
+          '--pid-file',
+          pidFile,
+        ],
+        {
+          detached: true,
+          stdio: 'ignore',
+        }
+      );
+      expect(fs.readFileSync(pidFile, 'utf8')).toBe('4321\n');
+      expect(unref).toHaveBeenCalled();
+      expect(mockSlackClient.setAssistantThreadStatus).not.toHaveBeenCalled();
+      fs.unlinkSync(pidFile);
+    });
+
+    it('should write and remove pid-file during foreground keep-alive', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const pidFile = tempPath('foreground.pid');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '1',
+        '--max-duration',
+        '1',
+        '--pid-file',
+        pidFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fs.readFileSync(pidFile, 'utf8')).toBe(`${process.pid}\n`);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await keepAlivePromise;
+
+      expect(fs.existsSync(pidFile)).toBe(false);
     });
 
     it('should stop on SIGINT and then clear status', async () => {
@@ -319,6 +434,125 @@ describe('status command', () => {
     });
   });
 
+  describe('stop subcommand', () => {
+    it('should touch stop-file, terminate pid, remove pid-file, and clear status', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const stopFile = tempPath('stop');
+      const pidFile = tempPath('keepalive.pid');
+      fs.writeFileSync(pidFile, '12345\n');
+      let terminated = false;
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+        if (pid !== 12345) {
+          return true;
+        }
+
+        if (signal === 'SIGTERM') {
+          terminated = true;
+          return true;
+        }
+
+        if (signal === 0 && terminated) {
+          throw notRunningError();
+        }
+
+        return true;
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'stop',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--stop-file',
+        stopFile,
+        '--pid-file',
+        pidFile,
+      ]);
+
+      expect(fs.existsSync(stopFile)).toBe(true);
+      expect(killSpy).toHaveBeenCalledWith(12345, 'SIGTERM');
+      expect(killSpy).not.toHaveBeenCalledWith(12345, 'SIGKILL');
+      expect(fs.existsSync(pidFile)).toBe(false);
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456'
+      );
+      fs.unlinkSync(stopFile);
+    });
+
+    it('should send SIGKILL after timeout when process is still running', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const pidFile = tempPath('timeout.pid');
+      fs.writeFileSync(pidFile, '23456\n');
+      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+      const stopPromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'stop',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--pid-file',
+        pidFile,
+        '--timeout',
+        '1',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await stopPromise;
+
+      expect(killSpy).toHaveBeenCalledWith(23456, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledWith(23456, 'SIGKILL');
+      expect(fs.existsSync(pidFile)).toBe(false);
+      expect(mockSlackClient.clearAssistantThreadStatus).toHaveBeenCalledWith(
+        'general',
+        '1234567890.123456'
+      );
+    });
+
+    it('should warn and still exit zero when pid-file is missing and clear fails', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockRejectedValue(
+        new Error('clear failed')
+      );
+      const pidFile = tempPath('missing.pid');
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'stop',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--pid-file',
+        pidFile,
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        expect.stringContaining('Failed to read pid-file')
+      );
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        expect.stringContaining('Failed to clear status')
+      );
+      expect(mockConsole.exitSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('validation', () => {
     it('should reject more than 10 loading messages', async () => {
       const statusCommand = setupStatusCommand();
@@ -354,6 +588,22 @@ describe('status command', () => {
           { from: 'user' }
         )
       ).rejects.toThrow('--interval must be a positive integer');
+    });
+
+    it('should require pid-file when keep-alive is detached', async () => {
+      const statusCommand = setupStatusCommand();
+      statusCommand.exitOverride();
+      const keepAliveCommand = statusCommand.commands.find(
+        (command) => command.name() === 'keep-alive'
+      )!;
+      keepAliveCommand.exitOverride();
+
+      await expect(
+        keepAliveCommand.parseAsync(
+          ['-c', 'general', '-t', '1234567890.123456', '--text', 'Working', '--detach'],
+          { from: 'user' }
+        )
+      ).rejects.toThrow('--pid-file is required when --detach is used');
     });
   });
 });

--- a/tests/utils/slack-api-client.test.ts
+++ b/tests/utils/slack-api-client.test.ts
@@ -6,6 +6,12 @@ vi.mock('@slack/web-api');
 
 describe('SlackApiClient', () => {
   type MockWebClient = {
+    assistant: {
+      threads: {
+        setStatus: ReturnType<typeof vi.fn>;
+      };
+    };
+    apiCall: ReturnType<typeof vi.fn>;
     chat: {
       postMessage: ReturnType<typeof vi.fn>;
       scheduleMessage: ReturnType<typeof vi.fn>;
@@ -33,6 +39,12 @@ describe('SlackApiClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockWebClient = {
+      assistant: {
+        threads: {
+          setStatus: vi.fn(),
+        },
+      },
+      apiCall: vi.fn(),
       chat: {
         postMessage: vi.fn(),
         scheduleMessage: vi.fn(),
@@ -148,6 +160,28 @@ describe('SlackApiClient', () => {
 
       expect(mockWebClient.chat.scheduledMessages.list).toHaveBeenCalledWith({ limit: 50 });
       expect(result).toEqual(mockResponse.scheduled_messages);
+    });
+  });
+
+  describe('setAssistantThreadStatus', () => {
+    it('should set assistant status for a thread', async () => {
+      const mockResponse = { ok: true };
+      vi.mocked(mockWebClient.assistant.threads.setStatus).mockResolvedValue(mockResponse as never);
+
+      const result = await client.setAssistantThreadStatus({
+        channel: 'C1234567890',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['Reading context'],
+      });
+
+      expect(mockWebClient.assistant.threads.setStatus).toHaveBeenCalledWith({
+        channel_id: 'C1234567890',
+        thread_ts: '1234567890.123456',
+        status: 'Working',
+        loading_messages: ['Reading context'],
+      });
+      expect(result).toEqual(mockResponse);
     });
   });
 

--- a/tests/utils/slack-operations/assistant-operations.test.ts
+++ b/tests/utils/slack-operations/assistant-operations.test.ts
@@ -1,0 +1,86 @@
+import { WebClient } from '@slack/web-api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { channelResolver } from '../../../src/utils/channel-resolver';
+import { AssistantOperations } from '../../../src/utils/slack-operations/assistant-operations';
+
+vi.mock('@slack/web-api');
+vi.mock('../../../src/utils/channel-resolver');
+
+describe('AssistantOperations', () => {
+  type MockClient = {
+    assistant?: {
+      threads?: {
+        setStatus?: ReturnType<typeof vi.fn>;
+      };
+    };
+    apiCall: ReturnType<typeof vi.fn>;
+  };
+
+  let assistantOps: AssistantOperations;
+  let mockClient: MockClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = {
+      assistant: {
+        threads: {
+          setStatus: vi.fn(),
+        },
+      },
+      apiCall: vi.fn(),
+    };
+    vi.mocked(WebClient).mockImplementation(function () {
+      return mockClient;
+    } as never);
+    vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C1234567890');
+    assistantOps = new AssistantOperations('test-token');
+  });
+
+  it('should call assistant.threads.setStatus with resolved channel ID', async () => {
+    vi.mocked(mockClient.assistant?.threads?.setStatus).mockResolvedValue({ ok: true });
+
+    await assistantOps.setThreadStatus({
+      channel: 'general',
+      threadTs: '1234567890.123456',
+      status: 'Working on it',
+      loadingMessages: ['Checking context', 'Calling tools'],
+    });
+
+    expect(channelResolver.resolveChannelId).toHaveBeenCalledWith('general', expect.any(Function));
+    expect(mockClient.assistant?.threads?.setStatus).toHaveBeenCalledWith({
+      channel_id: 'C1234567890',
+      thread_ts: '1234567890.123456',
+      status: 'Working on it',
+      loading_messages: ['Checking context', 'Calling tools'],
+    });
+  });
+
+  it('should fall back to apiCall when typed helper is unavailable', async () => {
+    mockClient.assistant = undefined;
+    vi.mocked(mockClient.apiCall).mockResolvedValue({ ok: true });
+
+    await assistantOps.setThreadStatus({
+      channel: 'general',
+      threadTs: '1234567890.123456',
+      status: 'Thinking',
+    });
+
+    expect(mockClient.apiCall).toHaveBeenCalledWith('assistant.threads.setStatus', {
+      channel_id: 'C1234567890',
+      thread_ts: '1234567890.123456',
+      status: 'Thinking',
+    });
+  });
+
+  it('should clear status by sending an empty status string', async () => {
+    vi.mocked(mockClient.assistant?.threads?.setStatus).mockResolvedValue({ ok: true });
+
+    await assistantOps.clearThreadStatus('general', '1234567890.123456');
+
+    expect(mockClient.assistant?.threads?.setStatus).toHaveBeenCalledWith({
+      channel_id: 'C1234567890',
+      thread_ts: '1234567890.123456',
+      status: '',
+    });
+  });
+});


### PR DESCRIPTION
# 背景

- Slack の `assistant.threads.setStatus` API を slack-cli から使えるようにします。
- Slack の 2026-03-05 changelog により、通常チャンネルのスレッドでも `chat:write` scope のみで assistant status を表示できます。
- GitHub Actions 側にあった keep-alive の nohup 起動、PID 管理、停止、clear のバックストップを CLI に集約し、action 側を薄いアダプタにできるようにします。

# 概要

- `slack-cli status set` を追加し、スレッドに status と任意の loading messages を設定できるようにしました。
- `slack-cli status clear` を追加し、空文字 status によるクリアをできるようにしました。
- `slack-cli status keep-alive` を追加し、Slack 側の約 2 分 timeout に合わせて status を定期再送できるようにしました。
- `status keep-alive --detach --pid-file <path>` を追加し、detached child process として keep-alive を起動して PID を記録できるようにしました。
- `--detach` なしの `status keep-alive --pid-file <path>` でも foreground process の PID を記録し、終了時に pid-file を削除します。
- `slack-cli status stop` を追加し、stop-file 作成、PID への SIGTERM/SIGKILL、pid-file 削除、最後の status clear を fail-soft に実行できるようにしました。
- keep-alive の stop-file 検知を最大 5 秒間隔にし、長い `--interval` でも stop-file 単独で数秒以内に停止できるようにしました。
- `src/utils/slack-operations/assistant-operations.ts` を追加し、`@slack/web-api` の typed helper が無い場合は `apiCall('assistant.threads.setStatus')` にフォールバックします。
- README / CHANGELOG / version を更新しました。

# 使用例

```bash
slack-cli status set -c C1234567890 -t 1719207629.000100 --text "Working on it"
slack-cli status set -c general -t 1719207629.000100 --text "Working on it" --loading-message "Reading context" --loading-message "Calling tools"
slack-cli status clear -c C1234567890 -t 1719207629.000100
slack-cli status keep-alive -c general -t 1719207629.000100 --text "Working on it" --interval 80 --max-duration 600 --stop-file /tmp/slack-cli-status.stop
slack-cli status keep-alive -c general -t 1719207629.000100 --text "Working on it" --interval 80 --max-duration 600 --stop-file /tmp/slack-cli-status.stop --detach --pid-file /tmp/slack-cli-status.pid
slack-cli status stop -c general -t 1719207629.000100 --stop-file /tmp/slack-cli-status.stop --pid-file /tmp/slack-cli-status.pid --timeout 5
```

# 必要 scope

- `chat:write`

# keep-alive / stop の終了仕様

- keep-alive は起動時に即時 set し、その後 `--interval` 秒ごとに再送します。
- keep-alive は `--max-duration` 経過、`--stop-file` の存在、SIGINT/SIGTERM のいずれかで終了します。
- stop-file は refresh interval に関係なく最大 5 秒程度で検知します。
- keep-alive はどの終了経路でも最後に status clear を送ります。
- keep-alive 中の一時的な set 失敗は警告して継続し、終了時の clear 失敗は無視して正常終了します。
- `status stop` は stop-file 作成、PID 停止、pid-file 削除、status clear をすべて fail-soft に扱い、warning のみで exit 0 にします。
- `status stop` は PID が生きている場合に SIGTERM を送り、`--timeout` 秒待っても生きていれば SIGKILL を送ります。
- keep-alive 側の finally と stop 側のバックストップで status clear が二重に呼ばれても無害です。

# 確認方法

- `npm run build`
- `npm test -- --run`
- `npm run check`
