### PR TITLE
status keep-alive に text-file オプションを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.24.0] - 2026-06-12
+
+### Added
+- Add `status keep-alive --text-file` for dynamic status text with `--text` fallback
+- Refresh keep-alive status immediately when text-file content changes during the 5-second poll loop
+
 ## [0.23.1] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working
   --max-duration 600 \
   --stop-file /tmp/slack-cli-status.stop
 
+# Keep status alive with dynamic status text from a file
+slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working on it" \
+  --text-file /tmp/slack-cli-status.txt \
+  --interval 80 \
+  --max-duration 600 \
+  --stop-file /tmp/slack-cli-status.stop
+
 # Run keep-alive in the background and record its PID
 slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working on it" \
   --interval 80 \
@@ -483,6 +490,11 @@ exists, or SIGINT/SIGTERM is received. Stop-file checks run at least every 5 sec
 the refresh interval is longer. Every exit path sends a final clear request; clear failures are
 ignored.
 
+With `--text-file`, the CLI reads status text from the file on each 5-second poll. Non-empty
+file content overrides `--text`; missing, empty, or unreadable files fall back to `--text`.
+When the resolved text changes, keep-alive sends the new status immediately instead of waiting
+for the next `--interval` refresh.
+
 With `--detach`, the CLI starts the same keep-alive command in a detached child process without
 `--detach`, writes the child PID to `--pid-file`, and exits immediately. Without `--detach`,
 `--pid-file` writes the foreground process PID and is removed when keep-alive exits.
@@ -492,6 +504,7 @@ With `--detach`, the CLI starts the same keep-alive command in a detached child 
 | --channel         | -c    | Target channel name or ID (required)                  |
 | --thread          | -t    | Thread parent timestamp (required)                    |
 | --text            |       | Status text (required)                                |
+| --text-file       |       | Read dynamic status text from this file               |
 | --interval        |       | Refresh interval in seconds (default: 80)             |
 | --max-duration    |       | Maximum duration in seconds (default: 600)            |
 | --stop-file       |       | Stop when this path exists                            |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.23.1",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -26,6 +26,7 @@ type StatusCommandOptions = {
   channel?: string;
   thread?: string;
   text?: string;
+  textFile?: string;
   interval?: string;
   maxDuration?: string;
   timeout?: string;
@@ -131,12 +132,19 @@ async function createStopFileAwareDelay(
   ms: number,
   isStopped: () => boolean,
   registerWake: (wake: (() => void) | undefined) => void,
-  stopFile?: string
+  stopFile?: string,
+  onPoll?: () => Promise<void>
 ): Promise<void> {
   const deadline = Date.now() + ms;
 
   while (!isStopped() && Date.now() < deadline) {
     if (stopFile && fs.existsSync(stopFile)) {
+      return;
+    }
+
+    await onPoll?.();
+
+    if (isStopped() || (stopFile && fs.existsSync(stopFile))) {
       return;
     }
 
@@ -150,6 +158,23 @@ async function createStopFileAwareDelay(
 
 function warn(message: string): void {
   console.error(chalk.yellow('Warning:'), message);
+}
+
+function resolveStatusText(text: string, textFile: string | undefined): string {
+  if (!textFile) {
+    return text;
+  }
+
+  try {
+    const content = fs.readFileSync(textFile, 'utf8').trim();
+    if (content === '') {
+      return text;
+    }
+
+    return content.replace(/[\r\n]+/g, '');
+  } catch {
+    return text;
+  }
 }
 
 async function clearStatusIgnoringErrors(
@@ -288,10 +313,41 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   const startedAt = Date.now();
   let stopRequested = false;
   let wakeDelay: (() => void) | undefined;
+  let lastSentStatus: string | undefined;
 
   const requestStop = () => {
     stopRequested = true;
     wakeDelay?.();
+  };
+
+  const setCurrentStatus = async (): Promise<void> => {
+    const status = resolveStatusText(options.text, options.textFile);
+    await client.setAssistantThreadStatus({
+      channel: options.channel,
+      threadTs: options.thread,
+      status,
+      loadingMessages: options.loadingMessage,
+    });
+    lastSentStatus = status;
+  };
+
+  const resendIfStatusTextChanged = async (): Promise<void> => {
+    const status = resolveStatusText(options.text, options.textFile);
+    if (status === lastSentStatus) {
+      return;
+    }
+
+    try {
+      await client.setAssistantThreadStatus({
+        channel: options.channel,
+        threadTs: options.thread,
+        status,
+        loadingMessages: options.loadingMessage,
+      });
+      lastSentStatus = status;
+    } catch (error) {
+      console.error(chalk.yellow('Warning:'), extractErrorMessage(error));
+    }
   };
 
   process.once('SIGINT', requestStop);
@@ -302,12 +358,7 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
       writePidFile(options.pidFile, process.pid);
     }
 
-    await client.setAssistantThreadStatus({
-      channel: options.channel,
-      threadTs: options.thread,
-      status: options.text,
-      loadingMessages: options.loadingMessage,
-    });
+    await setCurrentStatus();
 
     while (!stopRequested) {
       const elapsedMs = Date.now() - startedAt;
@@ -322,7 +373,8 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
         (wake) => {
           wakeDelay = wake;
         },
-        options.stopFile
+        options.stopFile,
+        options.textFile ? resendIfStatusTextChanged : undefined
       );
 
       if (stopRequested) {
@@ -338,12 +390,7 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
       }
 
       try {
-        await client.setAssistantThreadStatus({
-          channel: options.channel,
-          threadTs: options.thread,
-          status: options.text,
-          loadingMessages: options.loadingMessage,
-        });
+        await setCurrentStatus();
       } catch (error) {
         console.error(chalk.yellow('Warning:'), extractErrorMessage(error));
       }
@@ -473,6 +520,7 @@ export function setupStatusCommand(): Command {
     .option('-c, --channel <channel>', 'Target channel name or ID')
     .option('-t, --thread <thread>', 'Thread parent timestamp')
     .requiredOption('--text <text>', 'Status text')
+    .option('--text-file <path>', 'Read status text from this file with --text as fallback')
     .option(
       '--interval <seconds>',
       'Seconds between status refreshes',

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -45,6 +45,7 @@ export interface StatusKeepAliveOptions {
   channel: string;
   thread: string;
   text: string;
+  textFile?: string;
   interval?: string;
   maxDuration?: string;
   stopFile?: string;

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -224,6 +224,195 @@ describe('status command', () => {
       );
     });
 
+    it('should fall back to --text when text-file is empty', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const textFile = tempPath('status.txt');
+      fs.writeFileSync(textFile, '\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Fallback',
+        '--text-file',
+        textFile,
+        '--interval',
+        '10',
+        '--max-duration',
+        '10',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Fallback',
+        loadingMessages: [],
+      });
+
+      await vi.advanceTimersByTimeAsync(10000);
+      await keepAlivePromise;
+      fs.unlinkSync(textFile);
+    });
+
+    it('should resend immediately when text-file content changes', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const textFile = tempPath('status.txt');
+      fs.writeFileSync(textFile, 'Phase 1\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Fallback',
+        '--text-file',
+        textFile,
+        '--interval',
+        '30',
+        '--max-duration',
+        '30',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenLastCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Phase 1',
+        loadingMessages: [],
+      });
+
+      fs.writeFileSync(textFile, 'Phase 2\n');
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(2);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenLastCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Phase 2',
+        loadingMessages: [],
+      });
+
+      await vi.advanceTimersByTimeAsync(25000);
+      await keepAlivePromise;
+      fs.unlinkSync(textFile);
+    });
+
+    it('should not resend immediately when text-file content is unchanged', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const textFile = tempPath('status.txt');
+      fs.writeFileSync(textFile, 'Working\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Fallback',
+        '--text-file',
+        textFile,
+        '--interval',
+        '30',
+        '--max-duration',
+        '30',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+
+      fs.writeFileSync(textFile, 'Working\n');
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(25000);
+      await keepAlivePromise;
+      fs.unlinkSync(textFile);
+    });
+
+    it('should continue with fallback text when text-file disappears', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const textFile = tempPath('status.txt');
+      fs.writeFileSync(textFile, 'Phase 1\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Fallback',
+        '--text-file',
+        textFile,
+        '--interval',
+        '30',
+        '--max-duration',
+        '35',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(1);
+
+      fs.unlinkSync(textFile);
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(2);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenLastCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Fallback',
+        loadingMessages: [],
+      });
+
+      await vi.advanceTimersByTimeAsync(25000);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledTimes(3);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenLastCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Fallback',
+        loadingMessages: [],
+      });
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+    });
+
     it('should spawn a detached copy without --detach and write child pid', async () => {
       const pidFile = tempPath('detached.pid');
       const originalArgv = process.argv;


### PR DESCRIPTION
# 背景

- `status keep-alive` は起動時の `--text` 固定文言のみを再送していたため、CI 内のエージェントなど外部プロセスが処理フェーズに応じてステータス文言を更新できませんでした。

# 概要

- `status keep-alive` に `--text-file <path>` を追加しました。
- ファイルが存在し、trim 後に非空ならその内容をステータス文言として使い、存在しない・空・読み取り失敗時は必須の `--text` にフォールバックします。
- 既存の stop-file 用 5 秒ポーリングループで text-file の変化も監視し、前回送信した文言から変わった場合は `--interval` を待たずに即時再送します。
- README / CHANGELOG を更新し、バージョンを `0.24.0` に上げました。

使用例:

```bash
slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working on it" \
  --text-file /tmp/slack-cli-status.txt \
  --interval 80 \
  --max-duration 600 \
  --stop-file /tmp/slack-cli-status.stop
```

# 関連情報

- Jira issue: なし

# 確認方法

- `npm run build`
- `npm test`
- `npm run check`
