### PR TITLE
Add keep-alive --log-file option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.0] - 2026-06-12
+
+### Added
+- Add `status keep-alive --log-file` to append timestamped activity logs (start, setStatus success/failure, text changes, stop reason) for observability of detached keep-alive processes
+
 ## [0.24.0] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working
   --max-duration 600 \
   --stop-file /tmp/slack-cli-status.stop
 
-# Run keep-alive in the background and record its PID
+# Run keep-alive in the background, record its PID, and log activity to a file
 slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working on it" \
   --interval 80 \
   --max-duration 600 \
   --stop-file /tmp/slack-cli-status.stop \
   --detach \
-  --pid-file /tmp/slack-cli-status.pid
+  --pid-file /tmp/slack-cli-status.pid \
+  --log-file /tmp/slack-cli-status.log
 
 # Stop a background keep-alive process and clear status as a backstop
 slack-cli status stop -c channel-name -t 1719207629.000100 \
@@ -499,6 +500,12 @@ With `--detach`, the CLI starts the same keep-alive command in a detached child 
 `--detach`, writes the child PID to `--pid-file`, and exits immediately. Without `--detach`,
 `--pid-file` writes the foreground process PID and is removed when keep-alive exits.
 
+With `--log-file`, keep-alive appends timestamped activity logs to the file: startup parameters,
+each `setStatus` success or failure with the error message, status text changes detected from
+`--text-file`, and the stop reason. The option is passed through to the detached child, so
+`--detach` runs stay traceable even though the child runs with `stdio: 'ignore'`. Log writes are
+best-effort and never interrupt keep-alive.
+
 | Option            | Short | Description                                           |
 | ----------------- | ----- | ----------------------------------------------------- |
 | --channel         | -c    | Target channel name or ID (required)                  |
@@ -510,6 +517,7 @@ With `--detach`, the CLI starts the same keep-alive command in a detached child 
 | --stop-file       |       | Stop when this path exists                            |
 | --detach          |       | Run keep-alive in a detached background process       |
 | --pid-file        |       | Write the keep-alive process ID to this file          |
+| --log-file        |       | Append timestamped activity logs to this file         |
 | --loading-message |       | Optional loading message; repeatable up to 10         |
 | --profile         |       | Use specific workspace profile                        |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -160,6 +160,29 @@ function warn(message: string): void {
   console.error(chalk.yellow('Warning:'), message);
 }
 
+type KeepAliveLogger = (message: string) => void;
+
+function createKeepAliveLogger(logFile: string | undefined): KeepAliveLogger {
+  if (!logFile) {
+    return () => {
+      // No-op when --log-file is not specified.
+    };
+  }
+
+  return (message) => {
+    try {
+      const directory = path.dirname(logFile);
+      if (directory && directory !== '.') {
+        fs.mkdirSync(directory, { recursive: true });
+      }
+
+      fs.appendFileSync(logFile, `[${new Date().toISOString()}] ${message}\n`);
+    } catch {
+      // Logging is best-effort and must not break keep-alive.
+    }
+  };
+}
+
 function resolveStatusText(text: string, textFile: string | undefined): string {
   if (!textFile) {
     return text;
@@ -214,7 +237,7 @@ function createDetachedArgs(): string[] {
   return process.argv.slice(1).filter((arg) => arg !== '--detach');
 }
 
-function runDetachedKeepAlive(options: StatusKeepAliveOptions): void {
+function runDetachedKeepAlive(options: StatusKeepAliveOptions, log: KeepAliveLogger): void {
   const child = spawn(process.execPath, createDetachedArgs(), {
     detached: true,
     stdio: 'ignore',
@@ -226,6 +249,7 @@ function runDetachedKeepAlive(options: StatusKeepAliveOptions): void {
 
   writePidFile(options.pidFile!, child.pid);
   child.unref();
+  log(`detached keep-alive started (pid=${child.pid})`);
 }
 
 function touchStopFile(stopFile: string): void {
@@ -293,8 +317,10 @@ async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boole
 }
 
 async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
+  const log = createKeepAliveLogger(options.logFile);
+
   if (options.detach) {
-    runDetachedKeepAlive(options);
+    runDetachedKeepAlive(options, log);
     return;
   }
 
@@ -322,21 +348,6 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
 
   const setCurrentStatus = async (): Promise<void> => {
     const status = resolveStatusText(options.text, options.textFile);
-    await client.setAssistantThreadStatus({
-      channel: options.channel,
-      threadTs: options.thread,
-      status,
-      loadingMessages: options.loadingMessage,
-    });
-    lastSentStatus = status;
-  };
-
-  const resendIfStatusTextChanged = async (): Promise<void> => {
-    const status = resolveStatusText(options.text, options.textFile);
-    if (status === lastSentStatus) {
-      return;
-    }
-
     try {
       await client.setAssistantThreadStatus({
         channel: options.channel,
@@ -345,6 +356,22 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
         loadingMessages: options.loadingMessage,
       });
       lastSentStatus = status;
+      log(`setStatus succeeded: "${status}"`);
+    } catch (error) {
+      log(`setStatus failed: ${extractErrorMessage(error)}`);
+      throw error;
+    }
+  };
+
+  const resendIfStatusTextChanged = async (): Promise<void> => {
+    const status = resolveStatusText(options.text, options.textFile);
+    if (status === lastSentStatus) {
+      return;
+    }
+
+    log(`status text changed: "${lastSentStatus}" -> "${status}"`);
+    try {
+      await setCurrentStatus();
     } catch (error) {
       console.error(chalk.yellow('Warning:'), extractErrorMessage(error));
     }
@@ -353,7 +380,14 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   process.once('SIGINT', requestStop);
   process.once('SIGTERM', requestStop);
 
+  let stopReason: string | undefined;
+
   try {
+    log(
+      `keep-alive started (pid=${process.pid}, channel=${options.channel}, ` +
+        `thread=${options.thread}, interval=${intervalSeconds}s, max-duration=${maxDurationSeconds}s)`
+    );
+
     if (options.pidFile) {
       writePidFile(options.pidFile, process.pid);
     }
@@ -364,6 +398,7 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
       const elapsedMs = Date.now() - startedAt;
       const remainingMs = maxDurationMs - elapsedMs;
       if (remainingMs <= 0) {
+        stopReason = 'max-duration reached';
         break;
       }
 
@@ -382,10 +417,12 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
       }
 
       if (options.stopFile && fs.existsSync(options.stopFile)) {
+        stopReason = 'stop-file detected';
         break;
       }
 
       if (Date.now() - startedAt >= maxDurationMs) {
+        stopReason = 'max-duration reached';
         break;
       }
 
@@ -395,11 +432,16 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
         console.error(chalk.yellow('Warning:'), extractErrorMessage(error));
       }
     }
+
+    if (stopRequested) {
+      stopReason = 'stop signal received';
+    }
   } finally {
     process.off('SIGINT', requestStop);
     process.off('SIGTERM', requestStop);
     await clearStatusIgnoringErrors(client, options.channel, options.thread);
     removeFileIgnoringErrors(options.pidFile);
+    log(`keep-alive stopped (${stopReason ?? 'error'})`);
   }
 }
 
@@ -552,6 +594,7 @@ export function setupStatusCommand(): Command {
     )
     .option('--detach', 'Run keep-alive in a detached background process')
     .option('--pid-file <path>', 'Write the keep-alive process ID to this file')
+    .option('--log-file <path>', 'Append timestamped keep-alive activity logs to this file')
     .action(wrapCommand(runKeepAlive));
 
   const stopCommand = new Command('stop')

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -335,7 +335,20 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   const intervalMs = intervalSeconds * 1000;
   const maxDurationMs = maxDurationSeconds * 1000;
   const profile = parseProfile(options.profile);
-  const client = await createSlackClient(profile);
+
+  log(
+    `keep-alive started (pid=${process.pid}, channel=${options.channel}, ` +
+      `thread=${options.thread}, interval=${intervalSeconds}s, max-duration=${maxDurationSeconds}s)`
+  );
+
+  let client: Awaited<ReturnType<typeof createSlackClient>>;
+  try {
+    client = await createSlackClient(profile);
+  } catch (error) {
+    log(`keep-alive startup failed: ${extractErrorMessage(error)}`);
+    throw error;
+  }
+
   const startedAt = Date.now();
   let stopRequested = false;
   let wakeDelay: (() => void) | undefined;
@@ -383,11 +396,6 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   let stopReason: string | undefined;
 
   try {
-    log(
-      `keep-alive started (pid=${process.pid}, channel=${options.channel}, ` +
-        `thread=${options.thread}, interval=${intervalSeconds}s, max-duration=${maxDurationSeconds}s)`
-    );
-
     if (options.pidFile) {
       writePidFile(options.pidFile, process.pid);
     }
@@ -433,7 +441,7 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
       }
     }
 
-    if (stopRequested) {
+    if (stopRequested && stopReason === undefined) {
       stopReason = 'stop signal received';
     }
   } finally {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -51,6 +51,7 @@ export interface StatusKeepAliveOptions {
   stopFile?: string;
   detach?: boolean;
   pidFile?: string;
+  logFile?: string;
   loadingMessage?: string[];
   profile?: string;
 }

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -623,6 +623,258 @@ describe('status command', () => {
     });
   });
 
+  describe('keep-alive --log-file', () => {
+    it('should append timestamped start, success, and stop entries to the log file', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const logFile = tempPath('keepalive.log');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+        '--log-file',
+        logFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+
+      const lines = fs.readFileSync(logFile, 'utf8').trim().split('\n');
+      fs.unlinkSync(logFile);
+
+      for (const line of lines) {
+        expect(line).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\] /);
+      }
+      expect(lines[0]).toContain(
+        'keep-alive started (pid=' +
+          `${process.pid}, channel=general, thread=1234567890.123456, interval=5s, max-duration=5s)`
+      );
+      expect(lines.some((line) => line.includes('setStatus succeeded: "Working"'))).toBe(true);
+      expect(lines.at(-1)).toContain('keep-alive stopped (max-duration reached)');
+    });
+
+    it('should log setStatus failures with the error message', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus)
+        .mockResolvedValueOnce({ ok: true })
+        .mockRejectedValueOnce(new Error('timeout'))
+        .mockResolvedValueOnce({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const logFile = tempPath('keepalive-failure.log');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '11',
+        '--log-file',
+        logFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(11000);
+      await keepAlivePromise;
+
+      const content = fs.readFileSync(logFile, 'utf8');
+      fs.unlinkSync(logFile);
+
+      expect(content).toContain('setStatus failed: timeout');
+      expect(content).toContain('setStatus succeeded: "Working"');
+    });
+
+    it('should log stop-file detection as the stop reason', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const stopFile = tempPath('log-stop');
+      const logFile = tempPath('keepalive-stopfile.log');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '80',
+        '--max-duration',
+        '60',
+        '--stop-file',
+        stopFile,
+        '--log-file',
+        logFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      fs.writeFileSync(stopFile, '');
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+      fs.unlinkSync(stopFile);
+
+      const content = fs.readFileSync(logFile, 'utf8');
+      fs.unlinkSync(logFile);
+
+      expect(content).toContain('keep-alive stopped (stop-file detected)');
+    });
+
+    it('should log status text changes detected from text-file', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const textFile = tempPath('log-status.txt');
+      const logFile = tempPath('keepalive-change.log');
+      fs.writeFileSync(textFile, 'Phase 1\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Fallback',
+        '--text-file',
+        textFile,
+        '--interval',
+        '30',
+        '--max-duration',
+        '30',
+        '--log-file',
+        logFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      fs.writeFileSync(textFile, 'Phase 2\n');
+      await vi.advanceTimersByTimeAsync(30000);
+      await keepAlivePromise;
+      fs.unlinkSync(textFile);
+
+      const content = fs.readFileSync(logFile, 'utf8');
+      fs.unlinkSync(logFile);
+
+      expect(content).toContain('status text changed: "Phase 1" -> "Phase 2"');
+      expect(content).toContain('setStatus succeeded: "Phase 2"');
+    });
+
+    it('should pass --log-file through to the detached child and log the spawn', async () => {
+      const pidFile = tempPath('detached-log.pid');
+      const logFile = tempPath('detached.log');
+      const originalArgv = process.argv;
+      const unref = vi.fn();
+      vi.mocked(spawn).mockReturnValue({
+        pid: 4321,
+        unref,
+      } as ReturnType<typeof spawn>);
+      process.argv = [
+        'node',
+        '/repo/dist/index.js',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--detach',
+        '--pid-file',
+        pidFile,
+        '--log-file',
+        logFile,
+      ];
+
+      try {
+        await program.parseAsync(process.argv);
+      } finally {
+        process.argv = originalArgv;
+      }
+
+      expect(spawn).toHaveBeenCalledWith(
+        process.execPath,
+        expect.arrayContaining(['--log-file', logFile]),
+        {
+          detached: true,
+          stdio: 'ignore',
+        }
+      );
+
+      const content = fs.readFileSync(logFile, 'utf8');
+      fs.unlinkSync(pidFile);
+      fs.unlinkSync(logFile);
+
+      expect(content).toContain('detached keep-alive started (pid=4321)');
+    });
+
+    it('should not create a log file when --log-file is omitted', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const logFile = tempPath('never-created.log');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+
+      expect(fs.existsSync(logFile)).toBe(false);
+    });
+  });
+
   describe('stop subcommand', () => {
     it('should touch stop-file, terminate pid, remove pid-file, and clear status', async () => {
       mockConfiguredClient();

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -843,6 +843,34 @@ describe('status command', () => {
       expect(content).toContain('detached keep-alive started (pid=4321)');
     });
 
+    it('should log startup failures when the Slack client cannot be created', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockRejectedValue(new Error('No configuration found'));
+      const logFile = tempPath('keepalive-startup-failure.log');
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--log-file',
+        logFile,
+      ]);
+
+      const content = fs.readFileSync(logFile, 'utf8');
+      fs.unlinkSync(logFile);
+
+      expect(content).toContain('keep-alive started (pid=');
+      expect(content).toContain('keep-alive startup failed: No configuration found');
+      expect(mockSlackClient.setAssistantThreadStatus).not.toHaveBeenCalled();
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
     it('should not create a log file when --log-file is omitted', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));


### PR DESCRIPTION
## 概要

`status keep-alive` に `--log-file <path>` オプションを追加します。

## 背景

`status keep-alive --detach` は子プロセスを `spawn(..., { detached: true, stdio: 'ignore' })` で起動するため、デーモン化した keep-alive の `assistant.threads.setStatus` 呼び出しの成否がどこにも記録されず、CI（GitHub Actions）実行後にステータス表示が実際に成功したか追跡できませんでした。

## 変更内容

- `--log-file <path>` 指定時、keep-alive の動作ログをタイムスタンプ（ISO 8601）付きで追記する
  - 起動パラメータ（pid / channel / thread / interval / max-duration）
  - `setStatus` の成功・失敗（エラーメッセージ付き）
  - `--text-file` による文言変更検知
  - 停止理由（max-duration reached / stop-file detected / stop signal received）
- `--detach` 時は子プロセスへ `--log-file` がそのまま引き継がれ、親プロセスは spawn した子の pid をログに記録する
- ログ書き込みは best-effort（失敗しても keep-alive を妨げない）
- 未指定時は現状どおり（ログファイルは作成されない）
- README にオプション・使用例を追記
- version 0.24.0 → 0.25.0（minor）

## テスト

- ユニットテスト6件追加（start/success/stop ログ、setStatus 失敗ログ、stop-file 検知理由、文言変更ログ、detach 引き継ぎ、未指定時の非作成）
- `npm run build` / `npm test` (751 passed) / `npm run check` 全通過