### PR TITLE
テストカバレッジを向上

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.25.1] - 2026-06-14
+
+### Added
+- Expand test coverage across command validation, Slack operation wrappers, formatter helpers, update checks, token encryption, and Dependabot risk evaluation
+
+### Fixed
+- Preserve valid channel creation timestamps when `created` is `0`, and emit `null` in channels JSON output when Slack omits the creation timestamp
+- Reject using the same path for `status keep-alive --pid-file` and `--log-file`
+
 ## [0.25.0] - 2026-06-12
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.25.0",
+      "version": "0.25.1",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/scripts/dependabot-risk.cjs
+++ b/scripts/dependabot-risk.cjs
@@ -161,4 +161,5 @@ module.exports = {
   evaluateDependabotRisk,
   normalizeMetadata,
   parseChangedFiles,
+  runCli,
 };

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -32,6 +32,7 @@ type StatusCommandOptions = {
   timeout?: string;
   detach?: boolean;
   pidFile?: string;
+  logFile?: string;
   loadingMessage?: string[];
 };
 
@@ -92,6 +93,18 @@ function validatePositiveIntegerOption(
 function validateDetachOptions(options: StatusCommandOptions): string | null {
   if (options.detach && !options.pidFile) {
     return '--pid-file is required when --detach is used';
+  }
+
+  return null;
+}
+
+function validateDistinctLifecycleFiles(options: StatusCommandOptions): string | null {
+  if (!options.pidFile || !options.logFile) {
+    return null;
+  }
+
+  if (path.resolve(options.pidFile) === path.resolve(options.logFile)) {
+    return '--pid-file and --log-file must be different paths';
   }
 
   return null;
@@ -598,6 +611,7 @@ export function setupStatusCommand(): Command {
         (options) => validatePositiveIntegerOption(options, 'interval', '--interval'),
         (options) => validatePositiveIntegerOption(options, 'maxDuration', '--max-duration'),
         validateDetachOptions,
+        validateDistinctLifecycleFiles,
       ])
     )
     .option('--detach', 'Run keep-alive in a detached background process')

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -182,13 +182,19 @@ function createKeepAliveLogger(logFile: string | undefined): KeepAliveLogger {
     };
   }
 
+  try {
+    const directory = path.dirname(logFile);
+    if (directory && directory !== '.') {
+      fs.mkdirSync(directory, { recursive: true });
+    }
+  } catch {
+    return () => {
+      // Logging is best-effort and must not break keep-alive.
+    };
+  }
+
   return (message) => {
     try {
-      const directory = path.dirname(logFile);
-      if (directory && directory !== '.') {
-        fs.mkdirSync(directory, { recursive: true });
-      }
-
       fs.appendFileSync(logFile, `[${new Date().toISOString()}] ${message}\n`);
     } catch {
       // Logging is best-effort and must not break keep-alive.

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -396,6 +396,11 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   let stopReason: string | undefined;
 
   try {
+    log(
+      `keep-alive started (pid=${process.pid}, channel=${options.channel}, ` +
+        `thread=${options.thread}, interval=${intervalSeconds}s, max-duration=${maxDurationSeconds}s)`
+    );
+
     if (options.pidFile) {
       writePidFile(options.pidFile, process.pid);
     }

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -396,11 +396,6 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   let stopReason: string | undefined;
 
   try {
-    log(
-      `keep-alive started (pid=${process.pid}, channel=${options.channel}, ` +
-        `thread=${options.thread}, interval=${intervalSeconds}s, max-duration=${maxDurationSeconds}s)`
-    );
-
     if (options.pidFile) {
       writePidFile(options.pidFile, process.pid);
     }

--- a/src/utils/channel-formatter.ts
+++ b/src/utils/channel-formatter.ts
@@ -23,7 +23,10 @@ export function mapChannelToInfo(channel: Channel): ChannelInfo {
     name: sanitizeTerminalText(channel.name || 'unnamed'),
     type,
     members: channel.num_members || 0,
-    created: channel.created ? formatUnixTimestamp(channel.created) : '',
+    created:
+      typeof channel.created === 'number' && Number.isFinite(channel.created)
+        ? formatUnixTimestamp(channel.created)
+        : '',
     purpose: sanitizeTerminalText(channel.purpose?.value || ''),
   };
 }

--- a/src/utils/channel-formatter.ts
+++ b/src/utils/channel-formatter.ts
@@ -23,7 +23,7 @@ export function mapChannelToInfo(channel: Channel): ChannelInfo {
     name: sanitizeTerminalText(channel.name || 'unnamed'),
     type,
     members: channel.num_members || 0,
-    created: formatUnixTimestamp(channel.created),
+    created: channel.created ? formatUnixTimestamp(channel.created) : '',
     purpose: sanitizeTerminalText(channel.purpose?.value || ''),
   };
 }

--- a/src/utils/formatters/channels-list-formatters.ts
+++ b/src/utils/formatters/channels-list-formatters.ts
@@ -40,7 +40,7 @@ class ChannelsJsonFormatter extends JsonFormatter<ChannelsListFormatterOptions> 
       name: channel.name,
       type: channel.type,
       members: channel.members,
-      created: channel.created + 'T00:00:00Z',
+      created: channel.created ? `${channel.created}T00:00:00Z` : null,
       purpose: channel.purpose,
     }));
   }

--- a/tests/commands/channels.test.ts
+++ b/tests/commands/channels.test.ts
@@ -201,6 +201,29 @@ describe('channels command', () => {
       const output = JSON.parse(mockConsole.logSpy.mock.calls[0][0] as string);
       expect(output[0].created).toBeNull();
     });
+
+    it('should preserve Unix epoch created value in JSON output', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listChannels).mockResolvedValue([
+        {
+          id: 'C1234567890',
+          name: 'general',
+          is_channel: true,
+          is_private: false,
+          num_members: 250,
+          created: 0,
+          purpose: { value: 'Company announcements' },
+        },
+      ]);
+
+      await program.parseAsync(['node', 'slack-cli', 'channels', '--format', 'json']);
+
+      const output = JSON.parse(mockConsole.logSpy.mock.calls[0][0] as string);
+      expect(output[0].created).toBe('1970-01-01T00:00:00Z');
+    });
   });
 
   describe('additional options', () => {

--- a/tests/commands/channels.test.ts
+++ b/tests/commands/channels.test.ts
@@ -179,6 +179,28 @@ describe('channels command', () => {
 
       expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('"name": "general"'));
     });
+
+    it('should output null created value in JSON when Slack omits created', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.listChannels).mockResolvedValue([
+        {
+          id: 'C1234567890',
+          name: 'general',
+          is_channel: true,
+          is_private: false,
+          num_members: 250,
+          purpose: { value: 'Company announcements' },
+        },
+      ]);
+
+      await program.parseAsync(['node', 'slack-cli', 'channels', '--format', 'json']);
+
+      const output = JSON.parse(mockConsole.logSpy.mock.calls[0][0] as string);
+      expect(output[0].created).toBeNull();
+    });
   });
 
   describe('additional options', () => {

--- a/tests/commands/config.test.ts
+++ b/tests/commands/config.test.ts
@@ -96,6 +96,41 @@ describe('profile config command', () => {
       stdinSpy.mockRestore();
     });
 
+    it('should reject using --token and --token-stdin together', async () => {
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'config',
+        'set',
+        '--token',
+        'test-token-123',
+        '--token-stdin',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('Cannot use --token and --token-stdin together')
+      );
+      expect(mockConfigManager.setToken).not.toHaveBeenCalled();
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should reject empty stdin input', async () => {
+      const stdinSpy = vi
+        .spyOn(process, 'stdin', 'get')
+        .mockReturnValue(Readable.from(['\n']) as unknown as NodeJS.ReadStream);
+
+      await program.parseAsync(['node', 'slack-cli', 'config', 'set', '--token-stdin']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('No token received from stdin')
+      );
+      expect(mockConfigManager.setToken).not.toHaveBeenCalled();
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+      stdinSpy.mockRestore();
+    });
+
     it('should show error when interactive prompt is unavailable', async () => {
       delete process.env.SLACK_CLI_TOKEN;
 
@@ -124,6 +159,17 @@ describe('profile config command', () => {
       expect(mockConfigManager.getConfig).toHaveBeenCalledWith('work');
       expect(mockConsole.logSpy).toHaveBeenCalledWith(
         expect.stringContaining('Configuration for profile "work":')
+      );
+    });
+
+    it('should show a setup hint when config is missing', async () => {
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue(null);
+      vi.mocked(mockConfigManager.getCurrentProfile).mockResolvedValue('default');
+
+      await program.parseAsync(['node', 'slack-cli', 'config', 'get']);
+
+      expect(mockConsole.logSpy).toHaveBeenCalledWith(
+        expect.stringContaining(ERROR_MESSAGES.NO_CONFIG('default'))
       );
     });
   });

--- a/tests/commands/history-validators.test.ts
+++ b/tests/commands/history-validators.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  prepareSinceTimestamp,
+  validateDateFormat,
+  validateMessageCount,
+} from '../../src/commands/history-validators';
+
+function commandThatThrows() {
+  return {
+    error: vi.fn((message: string) => {
+      throw new Error(message);
+    }),
+  };
+}
+
+describe('history validators', () => {
+  it('accepts absent and in-range message counts', () => {
+    const command = commandThatThrows();
+
+    expect(validateMessageCount(undefined, command as never)).toBeUndefined();
+    expect(validateMessageCount('25', command as never)).toBe(25);
+    expect(command.error).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-numeric and out-of-range message counts', () => {
+    const command = commandThatThrows();
+
+    expect(() => validateMessageCount('abc', command as never)).toThrow(
+      'Message count must be between'
+    );
+    expect(() => validateMessageCount('0', command as never)).toThrow(
+      'Message count must be between'
+    );
+    expect(() => validateMessageCount('1001', command as never)).toThrow(
+      'Message count must be between'
+    );
+  });
+
+  it('accepts absent and parseable date values', () => {
+    const command = commandThatThrows();
+
+    expect(validateDateFormat(undefined, command as never)).toBeUndefined();
+    expect(validateDateFormat('2026-06-14 12:34:56', command as never)).toBe('2026-06-14 12:34:56');
+    expect(command.error).not.toHaveBeenCalled();
+  });
+
+  it('rejects unparseable date values', () => {
+    const command = commandThatThrows();
+
+    expect(() => validateDateFormat('not-a-date', command as never)).toThrow('Invalid date format');
+  });
+
+  it('converts a since date into a Slack timestamp string', () => {
+    expect(prepareSinceTimestamp(undefined)).toBeUndefined();
+    expect(prepareSinceTimestamp('1970-01-01T00:01:05.000Z')).toBe('65');
+  });
+});

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -1310,6 +1310,34 @@ describe('status command', () => {
       ).rejects.toThrow('--pid-file is required when --detach is used');
     });
 
+    it('should reject using the same path for pid-file and log-file', async () => {
+      const statusCommand = setupStatusCommand();
+      statusCommand.exitOverride();
+      const keepAliveCommand = statusCommand.commands.find(
+        (command) => command.name() === 'keep-alive'
+      )!;
+      keepAliveCommand.exitOverride();
+      const sharedPath = tempPath('shared-lifecycle-file');
+
+      await expect(
+        keepAliveCommand.parseAsync(
+          [
+            '-c',
+            'general',
+            '-t',
+            '1234567890.123456',
+            '--text',
+            'Working',
+            '--pid-file',
+            sharedPath,
+            '--log-file',
+            sharedPath,
+          ],
+          { from: 'user' }
+        )
+      ).rejects.toThrow('--pid-file and --log-file must be different paths');
+    });
+
     it('should reject invalid stop timeout', async () => {
       const statusCommand = setupStatusCommand();
       statusCommand.exitOverride();

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -477,6 +477,39 @@ describe('status command', () => {
       fs.unlinkSync(pidFile);
     });
 
+    it('should report an error when detached spawn does not return a pid', async () => {
+      const pidFile = tempPath('detached-missing-pid.pid');
+      vi.mocked(spawn).mockReturnValue({
+        pid: undefined,
+        unref: vi.fn(),
+      } as ReturnType<typeof spawn>);
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--detach',
+        '--pid-file',
+        pidFile,
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        expect.stringContaining('Failed to start detached keep-alive process')
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+      if (fs.existsSync(pidFile)) {
+        fs.unlinkSync(pidFile);
+      }
+    });
+
     it('should write and remove pid-file during foreground keep-alive', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
@@ -794,6 +827,50 @@ describe('status command', () => {
       expect(content).toContain('setStatus succeeded: "Phase 2"');
     });
 
+    it('should warn when a text-file change refresh fails', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus)
+        .mockResolvedValueOnce({ ok: true })
+        .mockRejectedValueOnce(new Error('refresh failed'));
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const textFile = tempPath('warn-status.txt');
+      fs.writeFileSync(textFile, 'Phase 1\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Fallback',
+        '--text-file',
+        textFile,
+        '--interval',
+        '30',
+        '--max-duration',
+        '30',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      fs.writeFileSync(textFile, 'Phase 2\n');
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        'refresh failed'
+      );
+
+      await vi.advanceTimersByTimeAsync(25000);
+      await keepAlivePromise;
+      fs.unlinkSync(textFile);
+    });
+
     it('should pass --log-file through to the detached child and log the spawn', async () => {
       const pidFile = tempPath('detached-log.pid');
       const logFile = tempPath('detached.log');
@@ -1020,9 +1097,151 @@ describe('status command', () => {
       );
       expect(mockConsole.exitSpy).not.toHaveBeenCalled();
     });
+
+    it('should warn and remove invalid pid-files', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const pidFile = tempPath('invalid.pid');
+      fs.writeFileSync(pidFile, 'not-a-pid\n');
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'stop',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--pid-file',
+        pidFile,
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        expect.stringContaining('Invalid pid-file')
+      );
+      expect(fs.existsSync(pidFile)).toBe(false);
+    });
+
+    it('should warn and remove pid-files for non-running processes', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const pidFile = tempPath('not-running.pid');
+      fs.writeFileSync(pidFile, '34567\n');
+      vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+        if (pid === 34567 && signal === 0) {
+          throw notRunningError();
+        }
+        return true;
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'stop',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--pid-file',
+        pidFile,
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        expect.stringContaining('Process 34567 is not running')
+      );
+      expect(fs.existsSync(pidFile)).toBe(false);
+    });
+
+    it('should warn when sending SIGTERM fails', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const pidFile = tempPath('signal-failure.pid');
+      fs.writeFileSync(pidFile, '45678\n');
+      vi.spyOn(process, 'kill').mockImplementation((pid, signal) => {
+        if (pid === 45678 && signal === 0) {
+          return true;
+        }
+        if (pid === 45678 && signal === 'SIGTERM') {
+          throw new Error('operation not permitted');
+        }
+        return true;
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'stop',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--pid-file',
+        pidFile,
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        expect.stringContaining('Failed to send SIGTERM to process 45678')
+      );
+      expect(fs.existsSync(pidFile)).toBe(false);
+    });
+
+    it('should warn when stop-file creation fails', async () => {
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const parentFile = tempPath('stop-parent');
+      fs.writeFileSync(parentFile, '');
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'stop',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--stop-file',
+        path.join(parentFile, 'stop'),
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Warning:'),
+        expect.stringContaining('Failed to create stop-file')
+      );
+      fs.unlinkSync(parentFile);
+    });
   });
 
   describe('validation', () => {
+    it('should require channel, thread, and text values', async () => {
+      const statusCommand = setupStatusCommand();
+      statusCommand.exitOverride();
+      const setCommand = statusCommand.commands.find((command) => command.name() === 'set')!;
+      setCommand.exitOverride();
+      const clearCommand = statusCommand.commands.find((command) => command.name() === 'clear')!;
+      clearCommand.exitOverride();
+
+      await expect(
+        setCommand.parseAsync(['-t', '1234567890.123456', '--text', 'Working'], { from: 'user' })
+      ).rejects.toThrow('--channel is required');
+
+      await expect(clearCommand.parseAsync(['-c', 'general'], { from: 'user' })).rejects.toThrow(
+        '--thread is required'
+      );
+
+      await expect(
+        setCommand.parseAsync(['-c', 'general', '-t', '1234567890.123456', '--text', ''], {
+          from: 'user',
+        })
+      ).rejects.toThrow('--text is required');
+    });
+
     it('should reject more than 10 loading messages', async () => {
       const statusCommand = setupStatusCommand();
       statusCommand.exitOverride();
@@ -1057,6 +1276,22 @@ describe('status command', () => {
           { from: 'user' }
         )
       ).rejects.toThrow('--interval must be a positive integer');
+
+      await expect(
+        keepAliveCommand.parseAsync(
+          [
+            '-c',
+            'general',
+            '-t',
+            '1234567890.123456',
+            '--text',
+            'Working',
+            '--max-duration',
+            'abc',
+          ],
+          { from: 'user' }
+        )
+      ).rejects.toThrow('--max-duration must be a positive integer');
     });
 
     it('should require pid-file when keep-alive is detached', async () => {
@@ -1073,6 +1308,19 @@ describe('status command', () => {
           { from: 'user' }
         )
       ).rejects.toThrow('--pid-file is required when --detach is used');
+    });
+
+    it('should reject invalid stop timeout', async () => {
+      const statusCommand = setupStatusCommand();
+      statusCommand.exitOverride();
+      const stopCommand = statusCommand.commands.find((command) => command.name() === 'stop')!;
+      stopCommand.exitOverride();
+
+      await expect(
+        stopCommand.parseAsync(['-c', 'general', '-t', '1234567890.123456', '--timeout', 'abc'], {
+          from: 'user',
+        })
+      ).rejects.toThrow('--timeout must be a positive integer');
     });
   });
 });

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -701,6 +701,44 @@ describe('status command', () => {
       expect(lines.at(-1)).toContain('keep-alive stopped (max-duration reached)');
     });
 
+    it('should create the log directory before writing entries', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const logDirectory = tempPath('keepalive-log-dir');
+      const logFile = path.join(logDirectory, 'keepalive.log');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+        '--log-file',
+        logFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+
+      const lines = fs.readFileSync(logFile, 'utf8').trim().split('\n');
+      expect(lines.length).toBeGreaterThan(1);
+      expect(lines[0]).toContain('keep-alive started');
+      expect(lines.at(-1)).toContain('keep-alive stopped (max-duration reached)');
+      fs.rmSync(logDirectory, { recursive: true, force: true });
+    });
+
     it('should log setStatus failures with the error message', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));

--- a/tests/dependabot-risk.test.ts
+++ b/tests/dependabot-risk.test.ts
@@ -1,8 +1,11 @@
+import fs from 'node:fs';
 import { createRequire } from 'node:module';
-import { describe, expect, it } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const require = createRequire(import.meta.url);
-const { evaluateDependabotRisk } =
+const { evaluateDependabotRisk, normalizeMetadata, parseChangedFiles, runCli } =
   require('../scripts/dependabot-risk.cjs') as typeof import('../scripts/dependabot-risk.cjs');
 
 const safeMetadata = {
@@ -14,6 +17,18 @@ const safeMetadata = {
 };
 
 describe('dependabot risk evaluator', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.CHANGED_FILES;
+    delete process.env.DEPENDENCY_NAMES;
+    delete process.env.DEPENDENCY_TYPE;
+    delete process.env.PACKAGE_ECOSYSTEM;
+    delete process.env.MAINTAINER_CHANGES;
+    delete process.env.UPDATE_TYPE;
+    delete process.env.GITHUB_OUTPUT;
+    process.exitCode = undefined;
+  });
+
   it('marks npm patch updates as safe', () => {
     const result = evaluateDependabotRisk({
       changedFiles: ['package.json', 'package-lock.json'],
@@ -105,5 +120,94 @@ describe('dependabot risk evaluator', () => {
     });
 
     expect(result.status).toBe('safe');
+  });
+
+  it('normalizes GitHub metadata keys and ecosystems', () => {
+    expect(
+      normalizeMetadata({
+        'dependency-names': 'vitest',
+        'dependency-type': 'direct:development',
+        'package-ecosystem': 'npm-and-yarn',
+        'maintainer-changes': true,
+        'update-type': 'version-update:semver-minor',
+      })
+    ).toEqual({
+      dependencyNames: 'vitest',
+      dependencyType: 'direct:development',
+      ecosystem: 'npm_and_yarn',
+      maintainerChanges: 'true',
+      updateType: 'version-update:semver-minor',
+    });
+  });
+
+  it('parses changed files from JSON, newline, comma, and empty input', () => {
+    expect(parseChangedFiles('["package.json","package-lock.json"]')).toEqual([
+      'package.json',
+      'package-lock.json',
+    ]);
+    expect(parseChangedFiles('package.json\npackage-lock.json, README.md')).toEqual([
+      'package.json',
+      'package-lock.json',
+      'README.md',
+    ]);
+    expect(parseChangedFiles('')).toEqual([]);
+  });
+
+  it('marks unsupported ecosystems and missing changed files as unsafe', () => {
+    expect(
+      evaluateDependabotRisk({
+        changedFiles: ['Cargo.toml'],
+        metadata: { ...safeMetadata, ecosystem: 'cargo' },
+      })
+    ).toMatchObject({
+      status: 'unsafe',
+      reason: expect.stringContaining('Unsupported ecosystem'),
+    });
+
+    expect(
+      evaluateDependabotRisk({
+        changedFiles: [],
+        metadata: safeMetadata,
+      })
+    ).toMatchObject({
+      status: 'unsafe',
+      reason: expect.stringContaining('No changed files'),
+    });
+  });
+
+  it('runs as a CLI, writes GitHub outputs, and keeps safe updates successful', () => {
+    const outputPath = path.join(os.tmpdir(), `dependabot-risk-${process.pid}.txt`);
+    fs.rmSync(outputPath, { force: true });
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    process.env.CHANGED_FILES = '["package.json","package-lock.json"]';
+    process.env.DEPENDENCY_NAMES = '@slack/web-api';
+    process.env.DEPENDENCY_TYPE = 'direct:production';
+    process.env.PACKAGE_ECOSYSTEM = 'npm';
+    process.env.MAINTAINER_CHANGES = 'false';
+    process.env.UPDATE_TYPE = 'version-update:semver-patch';
+    process.env.GITHUB_OUTPUT = outputPath;
+
+    runCli();
+
+    expect(process.exitCode).toBeUndefined();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('safe:'));
+    expect(fs.readFileSync(outputPath, 'utf8')).toContain('status=safe\n');
+    fs.rmSync(outputPath, { force: true });
+  });
+
+  it('runs as a CLI and sets a failing exit code for unsafe updates', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    process.env.CHANGED_FILES = 'package.json';
+    process.env.DEPENDENCY_NAMES = '@slack/web-api';
+    process.env.PACKAGE_ECOSYSTEM = 'npm';
+    process.env.MAINTAINER_CHANGES = 'yes';
+    process.env.UPDATE_TYPE = 'version-update:semver-patch';
+
+    runCli();
+
+    expect(process.exitCode).toBe(1);
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('unsafe:'));
   });
 });

--- a/tests/utils/channel-formatter.test.ts
+++ b/tests/utils/channel-formatter.test.ts
@@ -30,6 +30,8 @@ describe('channel-formatter', () => {
     expect(mapChannelToInfo({ id: 'M1', is_mpim: true }).type).toBe('mpim');
     expect(mapChannelToInfo({ id: 'X1' }).type).toBe('unknown');
     expect(mapChannelToInfo({ id: 'X1' }).name).toBe('unnamed');
+    expect(mapChannelToInfo({ id: 'X1' }).created).toBe('');
+    expect(mapChannelToInfo({ id: 'X1', created: 0 }).created).toBe('1970-01-01');
   });
 
   it('formats channel names safely', () => {

--- a/tests/utils/channel-formatter.test.ts
+++ b/tests/utils/channel-formatter.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatChannelName,
+  getChannelTypes,
+  mapChannelToInfo,
+} from '../../src/utils/channel-formatter';
+
+describe('channel-formatter', () => {
+  it('maps Slack channel variants to display info', () => {
+    expect(
+      mapChannelToInfo({
+        id: 'C1',
+        name: '\u001b[31mgeneral\u001b[0m',
+        is_channel: true,
+        is_private: false,
+        num_members: 12,
+        created: 65,
+        purpose: { value: '\u001b[31mannouncements\u001b[0m' },
+      })
+    ).toMatchObject({
+      id: 'C1',
+      name: 'general',
+      type: 'public',
+      members: 12,
+      purpose: 'announcements',
+    });
+
+    expect(mapChannelToInfo({ id: 'G1', is_group: true }).type).toBe('private');
+    expect(mapChannelToInfo({ id: 'D1', is_im: true }).type).toBe('im');
+    expect(mapChannelToInfo({ id: 'M1', is_mpim: true }).type).toBe('mpim');
+    expect(mapChannelToInfo({ id: 'X1' }).type).toBe('unknown');
+    expect(mapChannelToInfo({ id: 'X1' }).name).toBe('unnamed');
+  });
+
+  it('formats channel names safely', () => {
+    expect(formatChannelName()).toBe('#unknown');
+    expect(formatChannelName('general')).toBe('#general');
+    expect(formatChannelName('#random')).toBe('#random');
+    expect(formatChannelName('\u001b[31mops\u001b[0m')).toBe('#ops');
+  });
+
+  it('maps command channel type names to Slack API type filters', () => {
+    expect(getChannelTypes('public')).toBe('public_channel');
+    expect(getChannelTypes('private')).toBe('private_channel');
+    expect(getChannelTypes('im')).toBe('im');
+    expect(getChannelTypes('mpim')).toBe('mpim');
+    expect(getChannelTypes('all')).toBe('public_channel,private_channel,mpim,im');
+    expect(getChannelTypes('unknown')).toBe('public_channel');
+  });
+});

--- a/tests/utils/constants.test.ts
+++ b/tests/utils/constants.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  API_LIMITS,
+  DEFAULT_PROFILE_NAME,
+  DEFAULTS,
+  ERROR_MESSAGES,
+  FILE_PERMISSIONS,
+  RATE_LIMIT,
+  SUCCESS_MESSAGES,
+  TIME_FORMAT,
+  TOKEN_MASK_LENGTH,
+  TOKEN_MIN_LENGTH,
+} from '../../src/utils/constants';
+
+describe('constants', () => {
+  it('exposes expected scalar configuration values', () => {
+    expect(TOKEN_MASK_LENGTH).toBe(4);
+    expect(TOKEN_MIN_LENGTH).toBe(9);
+    expect(DEFAULT_PROFILE_NAME).toBe('default');
+    expect(FILE_PERMISSIONS.CONFIG_DIR).toBe(0o700);
+    expect(FILE_PERMISSIONS.CONFIG_FILE).toBe(0o600);
+    expect(API_LIMITS.MIN_MESSAGE_COUNT).toBe(1);
+    expect(RATE_LIMIT.CONCURRENT_REQUESTS).toBeGreaterThan(0);
+    expect(DEFAULTS.CHANNELS_LIMIT).toBeGreaterThan(0);
+    expect(TIME_FORMAT).toBe('YYYY-MM-DD HH:mm:ss');
+  });
+
+  it('formats error and success messages', () => {
+    expect(ERROR_MESSAGES.NO_CONFIG('work')).toContain('profile "work"');
+    expect(ERROR_MESSAGES.PROFILE_NOT_FOUND('work')).toBe('Profile "work" not found');
+    expect(ERROR_MESSAGES.API_ERROR('invalid_auth')).toBe('API Error: invalid_auth');
+    expect(ERROR_MESSAGES.CHANNEL_NOT_FOUND('general')).toBe('Channel not found: general');
+    expect(ERROR_MESSAGES.FILE_READ_ERROR('msg.txt', 'denied')).toBe(
+      'Error reading file msg.txt: denied'
+    );
+    expect(ERROR_MESSAGES.FILE_NOT_FOUND('msg.txt')).toBe('File not found: msg.txt');
+    expect(ERROR_MESSAGES.ERROR_LISTING_CHANNELS('rate_limited')).toBe(
+      'Error listing channels: rate_limited'
+    );
+
+    expect(SUCCESS_MESSAGES.TOKEN_SAVED('work')).toContain('profile "work"');
+    expect(SUCCESS_MESSAGES.PROFILE_SWITCHED('work')).toContain('profile "work"');
+    expect(SUCCESS_MESSAGES.PROFILE_CLEARED('work')).toContain('Profile "work"');
+    expect(SUCCESS_MESSAGES.MESSAGE_SENT('general')).toContain('#general');
+    expect(SUCCESS_MESSAGES.MESSAGE_SCHEDULED('general', '2026-06-14T00:00:00.000Z')).toContain(
+      '#general'
+    );
+    expect(SUCCESS_MESSAGES.EPHEMERAL_MESSAGE_SENT('general')).toContain('#general');
+  });
+});

--- a/tests/utils/slack-client-service.test.ts
+++ b/tests/utils/slack-client-service.test.ts
@@ -1,0 +1,343 @@
+import { WebClient } from '@slack/web-api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SlackApiClient, slackApiClient } from '../../src/utils/slack-client-service';
+
+vi.mock('@slack/web-api', () => ({
+  LogLevel: { ERROR: 'ERROR' },
+  WebClient: vi.fn(),
+}));
+
+function mockWebClient(instance: unknown) {
+  vi.mocked(WebClient).mockImplementation(
+    class {
+      constructor() {
+        return instance;
+      }
+    } as never
+  );
+}
+
+function createClientWithOps() {
+  const client = new SlackApiClient('test-token') as SlackApiClient & Record<string, unknown>;
+  const ops = {
+    assistantOps: {
+      clearThreadStatus: vi.fn().mockResolvedValue('clearThreadStatus-result'),
+      setThreadStatus: vi.fn().mockResolvedValue('setThreadStatus-result'),
+    },
+    canvasOps: {
+      listCanvases: vi.fn().mockResolvedValue('listCanvases-result'),
+      readCanvas: vi.fn().mockResolvedValue('readCanvas-result'),
+      writeCanvas: vi.fn().mockResolvedValue('writeCanvas-result'),
+    },
+    channelOps: {
+      enrichUnreadChannels: vi.fn().mockResolvedValue('enrichedUnreadChannels-result'),
+      getChannelDetail: vi.fn().mockResolvedValue('getChannelDetail-result'),
+      getChannelMembers: vi.fn().mockResolvedValue('getChannelMembers-result'),
+      inviteToChannel: vi.fn().mockResolvedValue('inviteToChannel-result'),
+      joinChannel: vi.fn().mockResolvedValue('joinChannel-result'),
+      leaveChannel: vi.fn().mockResolvedValue('leaveChannel-result'),
+      listChannels: vi.fn().mockResolvedValue('listChannels-result'),
+      listUnreadChannels: vi.fn().mockResolvedValue('fallbackUnreadChannels-result'),
+      setPurpose: vi.fn().mockResolvedValue('setPurpose-result'),
+      setTopic: vi.fn().mockResolvedValue('setTopic-result'),
+    },
+    fileOps: {
+      downloadFile: vi.fn().mockResolvedValue('downloadFile-result'),
+      uploadFile: vi.fn().mockResolvedValue('uploadFile-result'),
+    },
+    messageOps: {
+      cancelScheduledMessage: vi.fn().mockResolvedValue('cancelScheduledMessage-result'),
+      deleteMessage: vi.fn().mockResolvedValue('deleteMessage-result'),
+      getChannelUnread: vi.fn().mockResolvedValue('getChannelUnread-result'),
+      getHistory: vi.fn().mockResolvedValue('getHistory-result'),
+      getMessage: vi.fn().mockResolvedValue('getMessage-result'),
+      getMessageWithUsers: vi.fn().mockResolvedValue('getMessageWithUsers-result'),
+      getPermalink: vi.fn().mockResolvedValue('getPermalink-result'),
+      getPermalinks: vi.fn().mockResolvedValue('getPermalinks-result'),
+      getThreadHistory: vi.fn().mockResolvedValue('getThreadHistory-result'),
+      listScheduledMessages: vi.fn().mockResolvedValue('listScheduledMessages-result'),
+      markAsRead: vi.fn().mockResolvedValue('markAsRead-result'),
+      scheduleMessage: vi.fn().mockResolvedValue('scheduleMessage-result'),
+      sendEphemeralMessage: vi.fn().mockResolvedValue('sendEphemeralMessage-result'),
+      sendMessage: vi.fn().mockResolvedValue('sendMessage-result'),
+      updateMessage: vi.fn().mockResolvedValue('updateMessage-result'),
+    },
+    pinOps: {
+      addPin: vi.fn().mockResolvedValue('addPin-result'),
+      listPins: vi.fn().mockResolvedValue('listPins-result'),
+      removePin: vi.fn().mockResolvedValue('removePin-result'),
+    },
+    reactionOps: {
+      addReaction: vi.fn().mockResolvedValue('addReaction-result'),
+      removeReaction: vi.fn().mockResolvedValue('removeReaction-result'),
+    },
+    reminderOps: {
+      addReminder: vi.fn().mockResolvedValue('addReminder-result'),
+      completeReminder: vi.fn().mockResolvedValue('completeReminder-result'),
+      deleteReminder: vi.fn().mockResolvedValue('deleteReminder-result'),
+      listReminders: vi.fn().mockResolvedValue('listReminders-result'),
+    },
+    searchOps: {
+      listUnreadChannels: vi.fn().mockResolvedValue(['unread-channel']),
+      searchMessages: vi.fn().mockResolvedValue('searchMessages-result'),
+    },
+    starOps: {
+      addStar: vi.fn().mockResolvedValue('addStar-result'),
+      listStars: vi.fn().mockResolvedValue('listStars-result'),
+      removeStar: vi.fn().mockResolvedValue('removeStar-result'),
+    },
+    userOps: {
+      getPresence: vi.fn().mockResolvedValue('getPresence-result'),
+      getUserInfo: vi.fn().mockResolvedValue('getUserInfo-result'),
+      listUsers: vi.fn().mockResolvedValue('listUsers-result'),
+      lookupByEmail: vi.fn().mockResolvedValue('lookupByEmail-result'),
+      openDmChannel: vi.fn().mockResolvedValue('openDmChannel-result'),
+      resolveUserIdByName: vi.fn().mockResolvedValue('resolveUserIdByName-result'),
+    },
+  };
+
+  Object.assign(client, ops);
+  return { client, ops };
+}
+
+describe('SlackApiClient service facade', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWebClient({
+      conversations: {
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+      },
+    });
+  });
+
+  it('delegates message operations', async () => {
+    const { client, ops } = createClientWithOps();
+
+    await expect(client.sendMessage('C1', 'hello', '1.2')).resolves.toBe('sendMessage-result');
+    expect(ops.messageOps.sendMessage).toHaveBeenCalledWith('C1', 'hello', '1.2');
+
+    await expect(client.sendEphemeralMessage('C1', 'U1', 'hello', '1.2')).resolves.toBe(
+      'sendEphemeralMessage-result'
+    );
+    expect(ops.messageOps.sendEphemeralMessage).toHaveBeenCalledWith('C1', 'U1', 'hello', '1.2');
+
+    await expect(client.scheduleMessage('C1', 'later', 123, '1.2')).resolves.toBe(
+      'scheduleMessage-result'
+    );
+    expect(ops.messageOps.scheduleMessage).toHaveBeenCalledWith('C1', 'later', 123, '1.2');
+
+    await expect(client.updateMessage('C1', '1.2', 'updated')).resolves.toBe(
+      'updateMessage-result'
+    );
+    expect(ops.messageOps.updateMessage).toHaveBeenCalledWith('C1', '1.2', 'updated');
+
+    await expect(client.deleteMessage('C1', '1.2')).resolves.toBe('deleteMessage-result');
+    expect(ops.messageOps.deleteMessage).toHaveBeenCalledWith('C1', '1.2');
+
+    await expect(client.listScheduledMessages('C1', 10)).resolves.toBe(
+      'listScheduledMessages-result'
+    );
+    expect(ops.messageOps.listScheduledMessages).toHaveBeenCalledWith('C1', 10);
+
+    await expect(client.cancelScheduledMessage('C1', 'Q1')).resolves.toBe(
+      'cancelScheduledMessage-result'
+    );
+    expect(ops.messageOps.cancelScheduledMessage).toHaveBeenCalledWith('C1', 'Q1');
+  });
+
+  it('delegates history, unread, and permalink operations', async () => {
+    const { client, ops } = createClientWithOps();
+    const options = { limit: 5 };
+
+    await expect(client.getHistory('C1', options)).resolves.toBe('getHistory-result');
+    expect(ops.messageOps.getHistory).toHaveBeenCalledWith('C1', options);
+
+    await expect(client.getThreadHistory('C1', '1.2')).resolves.toBe('getThreadHistory-result');
+    expect(ops.messageOps.getThreadHistory).toHaveBeenCalledWith('C1', '1.2');
+
+    await expect(client.getMessage('C1', '2.3', '1.2')).resolves.toBe('getMessage-result');
+    expect(ops.messageOps.getMessage).toHaveBeenCalledWith('C1', '2.3', '1.2');
+
+    await expect(client.getMessageWithUsers('C1', '2.3', '1.2')).resolves.toBe(
+      'getMessageWithUsers-result'
+    );
+    expect(ops.messageOps.getMessageWithUsers).toHaveBeenCalledWith('C1', '2.3', '1.2');
+
+    await expect(client.getChannelUnread('general')).resolves.toBe('getChannelUnread-result');
+    expect(ops.messageOps.getChannelUnread).toHaveBeenCalledWith('general');
+
+    await expect(client.markAsRead('C1')).resolves.toBe('markAsRead-result');
+    expect(ops.messageOps.markAsRead).toHaveBeenCalledWith('C1');
+
+    await expect(client.getPermalink('C1', '1.2')).resolves.toBe('getPermalink-result');
+    expect(ops.messageOps.getPermalink).toHaveBeenCalledWith('C1', '1.2');
+
+    await expect(client.getPermalinks('C1', ['1.2', '2.3'])).resolves.toBe('getPermalinks-result');
+    expect(ops.messageOps.getPermalinks).toHaveBeenCalledWith('C1', ['1.2', '2.3']);
+  });
+
+  it('delegates channel operations and unread enrichment', async () => {
+    const { client, ops } = createClientWithOps();
+    const listOptions = { types: 'public_channel', limit: 20 };
+    const memberOptions = { limit: 10 };
+
+    await expect(client.listChannels(listOptions)).resolves.toBe('listChannels-result');
+    expect(ops.channelOps.listChannels).toHaveBeenCalledWith(listOptions);
+
+    await expect(client.getChannelDetail('general')).resolves.toBe('getChannelDetail-result');
+    expect(ops.channelOps.getChannelDetail).toHaveBeenCalledWith('general');
+
+    await expect(client.setTopic('general', 'topic')).resolves.toBe('setTopic-result');
+    expect(ops.channelOps.setTopic).toHaveBeenCalledWith('general', 'topic');
+
+    await expect(client.setPurpose('general', 'purpose')).resolves.toBe('setPurpose-result');
+    expect(ops.channelOps.setPurpose).toHaveBeenCalledWith('general', 'purpose');
+
+    await expect(client.listUnreadChannels()).resolves.toBe('enrichedUnreadChannels-result');
+    expect(ops.searchOps.listUnreadChannels).toHaveBeenCalledWith();
+    expect(ops.channelOps.enrichUnreadChannels).toHaveBeenCalledWith(['unread-channel']);
+
+    await expect(client.joinChannel('general')).resolves.toBe('joinChannel-result');
+    expect(ops.channelOps.joinChannel).toHaveBeenCalledWith('general');
+
+    await expect(client.leaveChannel('general')).resolves.toBe('leaveChannel-result');
+    expect(ops.channelOps.leaveChannel).toHaveBeenCalledWith('general');
+
+    await expect(client.inviteToChannel('general', ['U1'], true)).resolves.toBe(
+      'inviteToChannel-result'
+    );
+    expect(ops.channelOps.inviteToChannel).toHaveBeenCalledWith('general', ['U1'], true);
+
+    await expect(client.getChannelMembers('general', memberOptions)).resolves.toBe(
+      'getChannelMembers-result'
+    );
+    expect(ops.channelOps.getChannelMembers).toHaveBeenCalledWith('general', memberOptions);
+  });
+
+  it('delegates file, reaction, pin, user, search, reminder, star, canvas, and assistant operations', async () => {
+    const { client, ops } = createClientWithOps();
+
+    await expect(client.uploadFile({ channels: ['C1'], file: 'a.txt' })).resolves.toBe(
+      'uploadFile-result'
+    );
+    expect(ops.fileOps.uploadFile).toHaveBeenCalledWith({ channels: ['C1'], file: 'a.txt' });
+
+    await expect(client.downloadFile({ url: 'https://example.com/file' })).resolves.toBe(
+      'downloadFile-result'
+    );
+    expect(ops.fileOps.downloadFile).toHaveBeenCalledWith({ url: 'https://example.com/file' });
+
+    await expect(client.addReaction('C1', '1.2', 'thumbsup')).resolves.toBe('addReaction-result');
+    expect(ops.reactionOps.addReaction).toHaveBeenCalledWith('C1', '1.2', 'thumbsup');
+
+    await expect(client.removeReaction('C1', '1.2', 'thumbsup')).resolves.toBe(
+      'removeReaction-result'
+    );
+    expect(ops.reactionOps.removeReaction).toHaveBeenCalledWith('C1', '1.2', 'thumbsup');
+
+    await expect(client.addPin('C1', '1.2')).resolves.toBe('addPin-result');
+    expect(ops.pinOps.addPin).toHaveBeenCalledWith('C1', '1.2');
+
+    await expect(client.removePin('C1', '1.2')).resolves.toBe('removePin-result');
+    expect(ops.pinOps.removePin).toHaveBeenCalledWith('C1', '1.2');
+
+    await expect(client.listPins('C1')).resolves.toBe('listPins-result');
+    expect(ops.pinOps.listPins).toHaveBeenCalledWith('C1');
+
+    await expect(client.listUsers(20)).resolves.toBe('listUsers-result');
+    expect(ops.userOps.listUsers).toHaveBeenCalledWith(20);
+
+    await expect(client.getUserInfo('U1')).resolves.toBe('getUserInfo-result');
+    expect(ops.userOps.getUserInfo).toHaveBeenCalledWith('U1');
+
+    await expect(client.lookupUserByEmail('a@example.com')).resolves.toBe('lookupByEmail-result');
+    expect(ops.userOps.lookupByEmail).toHaveBeenCalledWith('a@example.com');
+
+    await expect(client.openDmChannel('U1')).resolves.toBe('openDmChannel-result');
+    expect(ops.userOps.openDmChannel).toHaveBeenCalledWith('U1');
+
+    await expect(client.getUserPresence('U1')).resolves.toBe('getPresence-result');
+    expect(ops.userOps.getPresence).toHaveBeenCalledWith('U1');
+
+    await expect(client.resolveUserIdByName('alice')).resolves.toBe('resolveUserIdByName-result');
+    expect(ops.userOps.resolveUserIdByName).toHaveBeenCalledWith('alice');
+
+    await expect(client.searchMessages('hello', { count: 5 })).resolves.toBe(
+      'searchMessages-result'
+    );
+    expect(ops.searchOps.searchMessages).toHaveBeenCalledWith('hello', { count: 5 });
+
+    await expect(client.addReminder('standup', 123)).resolves.toBe('addReminder-result');
+    expect(ops.reminderOps.addReminder).toHaveBeenCalledWith('standup', 123);
+
+    await expect(client.listReminders()).resolves.toBe('listReminders-result');
+    expect(ops.reminderOps.listReminders).toHaveBeenCalledWith();
+
+    await expect(client.deleteReminder('R1')).resolves.toBe('deleteReminder-result');
+    expect(ops.reminderOps.deleteReminder).toHaveBeenCalledWith('R1');
+
+    await expect(client.completeReminder('R1')).resolves.toBe('completeReminder-result');
+    expect(ops.reminderOps.completeReminder).toHaveBeenCalledWith('R1');
+
+    await expect(client.addStar('C1', '1.2')).resolves.toBe('addStar-result');
+    expect(ops.starOps.addStar).toHaveBeenCalledWith('C1', '1.2');
+
+    await expect(client.listStars(10)).resolves.toBe('listStars-result');
+    expect(ops.starOps.listStars).toHaveBeenCalledWith(10);
+
+    await expect(client.removeStar('C1', '1.2')).resolves.toBe('removeStar-result');
+    expect(ops.starOps.removeStar).toHaveBeenCalledWith('C1', '1.2');
+
+    await expect(client.readCanvas('F1')).resolves.toBe('readCanvas-result');
+    expect(ops.canvasOps.readCanvas).toHaveBeenCalledWith('F1');
+
+    await expect(client.listCanvases('C1')).resolves.toBe('listCanvases-result');
+    expect(ops.canvasOps.listCanvases).toHaveBeenCalledWith('C1');
+
+    await expect(client.writeCanvas('F1', 'body', 'end')).resolves.toBe('writeCanvas-result');
+    expect(ops.canvasOps.writeCanvas).toHaveBeenCalledWith('F1', 'body', 'end');
+
+    await expect(
+      client.setAssistantThreadStatus({
+        channel: 'C1',
+        threadTs: '1.2',
+        status: 'working',
+      })
+    ).resolves.toBe('setThreadStatus-result');
+    expect(ops.assistantOps.setThreadStatus).toHaveBeenCalledWith({
+      channel: 'C1',
+      threadTs: '1.2',
+      status: 'working',
+    });
+
+    await expect(client.clearAssistantThreadStatus('C1', '1.2')).resolves.toBe(
+      'clearThreadStatus-result'
+    );
+    expect(ops.assistantOps.clearThreadStatus).toHaveBeenCalledWith('C1', '1.2');
+  });
+
+  it('keeps the legacy listChannels helper as a token-based adapter', async () => {
+    const conversationsList = vi.fn().mockResolvedValue({
+      channels: [{ id: 'C1', name: 'general' }],
+      response_metadata: { next_cursor: '' },
+    });
+    mockWebClient({
+      conversations: { list: conversationsList },
+    });
+
+    await expect(
+      slackApiClient.listChannels('token', {
+        types: 'public_channel',
+        exclude_archived: true,
+        limit: 100,
+      })
+    ).resolves.toEqual([{ id: 'C1', name: 'general' }]);
+
+    expect(WebClient).toHaveBeenCalledWith('token', expect.any(Object));
+    expect(conversationsList).toHaveBeenCalledWith({
+      types: 'public_channel',
+      exclude_archived: true,
+      limit: 100,
+    });
+  });
+});

--- a/tests/utils/slack-operations/base-client.test.ts
+++ b/tests/utils/slack-operations/base-client.test.ts
@@ -1,0 +1,110 @@
+import { LogLevel, WebClient } from '@slack/web-api';
+import pLimit from 'p-limit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BaseSlackClient,
+  createSlackClientContext,
+} from '../../../src/utils/slack-operations/base-client';
+
+vi.mock('@slack/web-api', () => ({
+  LogLevel: { ERROR: 'error' },
+  WebClient: vi.fn(),
+}));
+
+class TestSlackClient extends BaseSlackClient {
+  getState() {
+    return {
+      client: this.client,
+      rateLimiter: this.rateLimiter,
+      token: this.token,
+    };
+  }
+
+  waitForRateLimit(error: unknown): Promise<void> {
+    return this.handleRateLimit(error);
+  }
+
+  wait(ms: number): Promise<void> {
+    return this.delay(ms);
+  }
+}
+
+function mockConstructedWebClient(instance: unknown) {
+  vi.mocked(WebClient).mockImplementation(
+    class {
+      constructor() {
+        return instance;
+      }
+    } as never
+  );
+}
+
+describe('base Slack client', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('creates a shared Slack client context from a token', () => {
+    const webClient = { chat: {} };
+    mockConstructedWebClient(webClient);
+
+    const context = createSlackClientContext('xoxb-token');
+
+    expect(WebClient).toHaveBeenCalledWith('xoxb-token', {
+      retryConfig: { retries: 0 },
+      logLevel: LogLevel.ERROR,
+    });
+    expect(context.client).toBe(webClient);
+    expect(context.token).toBe('xoxb-token');
+    expect(typeof context.rateLimiter).toBe('function');
+  });
+
+  it('accepts token, shared context, and raw WebClient dependencies', () => {
+    const webClient = { chat: {} };
+    mockConstructedWebClient(webClient);
+
+    expect(new TestSlackClient('xoxb-token').getState()).toMatchObject({
+      client: webClient,
+      token: 'xoxb-token',
+    });
+
+    const sharedContext = {
+      client: { files: {} } as never,
+      rateLimiter: pLimit(1),
+      token: 'shared-token',
+    };
+    expect(new TestSlackClient(sharedContext).getState()).toMatchObject({
+      client: sharedContext.client,
+      rateLimiter: sharedContext.rateLimiter,
+      token: 'shared-token',
+    });
+
+    const rawClient = { users: {} } as never;
+    const rawState = new TestSlackClient(rawClient).getState();
+    expect(rawState.client).toBe(rawClient);
+    expect(rawState.token).toBeUndefined();
+    expect(typeof rawState.rateLimiter).toBe('function');
+  });
+
+  it('waits only for rate limit errors and exposes delay for subclasses', async () => {
+    vi.useFakeTimers();
+    const client = new TestSlackClient({ apiCall: vi.fn() } as never);
+
+    const rateLimitPromise = client.waitForRateLimit(new Error('hit rate limit'));
+    await vi.advanceTimersByTimeAsync(4999);
+    let resolved = false;
+    rateLimitPromise.then(() => {
+      resolved = true;
+    });
+    await vi.advanceTimersByTimeAsync(1);
+    await rateLimitPromise;
+    expect(resolved).toBe(true);
+
+    await expect(client.waitForRateLimit(new Error('other error'))).resolves.toBeUndefined();
+
+    const delayPromise = client.wait(25);
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(delayPromise).resolves.toBeUndefined();
+  });
+});

--- a/tests/utils/slack-operations/canvas-operations.test.ts
+++ b/tests/utils/slack-operations/canvas-operations.test.ts
@@ -28,6 +28,9 @@ describe('CanvasOperations', () => {
         lookup: ReturnType<typeof vi.fn>;
       };
     };
+    files: {
+      list: ReturnType<typeof vi.fn>;
+    };
   };
 
   let canvasOps: CanvasOperations;
@@ -123,6 +126,61 @@ describe('CanvasOperations', () => {
       await expect(canvasOps.writeCanvas('invalid-id', '追記する内容', 'end')).rejects.toThrow(
         'canvas_not_found'
       );
+    });
+  });
+
+  describe('readCanvas', () => {
+    it('should look up canvas header sections', async () => {
+      mockClient.canvases.sections.lookup.mockResolvedValue({
+        sections: [{ id: 'S1', type: 'h1', text: 'Title' }],
+      });
+
+      const result = await canvasOps.readCanvas('F0AJ4852CQN');
+
+      expect(mockClient.canvases.sections.lookup).toHaveBeenCalledWith({
+        canvas_id: 'F0AJ4852CQN',
+        criteria: { section_types: ['any_header'] },
+      });
+      expect(result).toEqual([{ id: 'S1', type: 'h1', text: 'Title' }]);
+    });
+
+    it('should return an empty list when the API omits sections', async () => {
+      mockClient.canvases.sections.lookup.mockResolvedValue({});
+
+      await expect(canvasOps.readCanvas('F0AJ4852CQN')).resolves.toEqual([]);
+    });
+  });
+
+  describe('listCanvases', () => {
+    it('should resolve channel names before listing canvas files', async () => {
+      const channelOps = {
+        resolveChannelId: vi.fn().mockResolvedValue('C1234567890'),
+      };
+      canvasOps = new CanvasOperations('test-token', channelOps as never);
+      mockClient = (canvasOps as unknown as { client: MockClient }).client;
+      mockClient.files.list.mockResolvedValue({
+        files: [{ id: 'F1', name: 'Project canvas' }],
+      });
+
+      const result = await canvasOps.listCanvases('general');
+
+      expect(channelOps.resolveChannelId).toHaveBeenCalledWith('general');
+      expect(mockClient.files.list).toHaveBeenCalledWith({
+        channel: 'C1234567890',
+        types: 'spaces',
+      });
+      expect(result).toEqual([{ id: 'F1', name: 'Project canvas' }]);
+    });
+
+    it('should return an empty list when the API omits files', async () => {
+      const channelOps = {
+        resolveChannelId: vi.fn().mockResolvedValue('C1234567890'),
+      };
+      canvasOps = new CanvasOperations('test-token', channelOps as never);
+      mockClient = (canvasOps as unknown as { client: MockClient }).client;
+      mockClient.files.list.mockResolvedValue({});
+
+      await expect(canvasOps.listCanvases('general')).resolves.toEqual([]);
     });
   });
 });

--- a/tests/utils/slack-operations/channel-operations.test.ts
+++ b/tests/utils/slack-operations/channel-operations.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ChannelOperations } from '../../../src/utils/slack-operations/channel-operations';
 
 vi.mock('@slack/web-api', () => ({
@@ -65,6 +65,10 @@ describe('ChannelOperations', () => {
     channelOps = new ChannelOperations('test-token');
     // Replace the client with our mock
     (channelOps as unknown as { client: MockClient }).client = mockClient;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   describe('fetchUserChannels', () => {
@@ -269,6 +273,14 @@ describe('ChannelOperations', () => {
       expect(mockClient.conversations.list).toHaveBeenCalledTimes(1);
     });
 
+    it('should rethrow missing_scope when needed scopes do not map to channel lookup types', async () => {
+      const missingScopeError = createMissingScopeError('chat:write');
+      mockClient.conversations.list.mockRejectedValueOnce(missingScopeError);
+
+      await expect(channelOps.resolveChannelId('general')).rejects.toBe(missingScopeError);
+      expect(mockClient.conversations.list).toHaveBeenCalledTimes(1);
+    });
+
     it('should not retry on non-missing_scope errors', async () => {
       mockClient.conversations.list.mockRejectedValueOnce(new Error('invalid_auth'));
 
@@ -392,6 +404,61 @@ describe('ChannelOperations', () => {
       expect(result[0].id).toBe('C333');
     });
 
+    it('should skip channels whose unread info lookup fails after rate-limit handling', async () => {
+      vi.useFakeTimers();
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [{ id: 'C222' }],
+        response_metadata: { next_cursor: '' },
+      });
+      mockClient.conversations.info.mockRejectedValue(new Error('rate limit'));
+
+      const resultPromise = channelOps.listUnreadChannels();
+      await vi.advanceTimersByTimeAsync(20000);
+
+      await expect(resultPromise).resolves.toEqual([]);
+    });
+
+    it('should enrich unread channels but keep originals when enrichment fails', async () => {
+      vi.useFakeTimers();
+      const originalChannel = { id: 'C222', unread_count: 1 };
+      mockClient.conversations.info.mockRejectedValue(new Error('rate limit'));
+
+      const resultPromise = channelOps.enrichUnreadChannels([originalChannel]);
+      await vi.advanceTimersByTimeAsync(20000);
+
+      await expect(resultPromise).resolves.toEqual([originalChannel]);
+    });
+
+    it('should retry channel info lookups after transient rate limits', async () => {
+      vi.useFakeTimers();
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [{ id: 'C777' }],
+        response_metadata: { next_cursor: '' },
+      });
+      mockClient.conversations.info
+        .mockRejectedValueOnce(new Error('rate limit'))
+        .mockResolvedValueOnce({
+          channel: {
+            id: 'C777',
+            name: 'busy-channel',
+            unread_count: 3,
+            unread_count_display: 3,
+          },
+        });
+
+      const resultPromise = channelOps.listUnreadChannels();
+      await vi.advanceTimersByTimeAsync(5000);
+
+      await expect(resultPromise).resolves.toEqual([
+        expect.objectContaining({
+          id: 'C777',
+          name: 'busy-channel',
+          unread_count: 3,
+        }),
+      ]);
+      expect(mockClient.conversations.info).toHaveBeenCalledTimes(2);
+    });
+
     it('should avoid conversations.info when users.conversations already includes unread counters', async () => {
       mockClient.users.conversations.mockResolvedValue({
         channels: [
@@ -484,6 +551,52 @@ describe('ChannelOperations', () => {
       expect(mockClient.users.info).toHaveBeenCalledWith({ user: 'U999' });
     });
 
+    it('should fall back to user ID when DM user lookup fails', async () => {
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [
+          { id: 'D999', is_im: true, user: 'U999', unread_count: 2, unread_count_display: 2 },
+        ],
+        response_metadata: { next_cursor: '' },
+      });
+      mockClient.users.info.mockRejectedValue(new Error('missing_scope'));
+
+      const result = await channelOps.listUnreadChannels();
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          id: 'D999',
+          display_name: '@U999',
+        }),
+      ]);
+    });
+
+    it('should use MPIM purpose or channel ID as display name fallback', async () => {
+      mockClient.users.conversations.mockResolvedValue({
+        channels: [
+          {
+            id: 'G123',
+            is_mpim: true,
+            unread_count: 1,
+            unread_count_display: 1,
+            purpose: { value: ' Project Group ' },
+          },
+          {
+            id: 'G456',
+            is_mpim: true,
+            unread_count: 1,
+            unread_count_display: 1,
+            purpose: { value: '  ' },
+          },
+        ],
+        response_metadata: { next_cursor: '' },
+      });
+
+      const result = await channelOps.listUnreadChannels();
+
+      expect(result[0]).toEqual(expect.objectContaining({ display_name: 'Project Group' }));
+      expect(result[1]).toEqual(expect.objectContaining({ display_name: 'G456' }));
+    });
+
     it('should sanitize resolved display names for unread conversations', async () => {
       mockClient.users.conversations.mockResolvedValue({
         channels: [
@@ -552,6 +665,26 @@ describe('ChannelOperations', () => {
 
       expect(result).toHaveLength(2);
       expect(mockClient.conversations.list).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getChannelInfo', () => {
+    it('should resolve names and fetch channel info without member counts', async () => {
+      mockClient.conversations.list.mockResolvedValue({
+        channels: [{ id: 'C123', name: 'general' }],
+        response_metadata: { next_cursor: '' },
+      });
+      mockClient.conversations.info.mockResolvedValue({
+        channel: { id: 'C123', name: 'general' },
+      });
+
+      await expect(channelOps.getChannelInfo('general')).resolves.toEqual({
+        id: 'C123',
+        name: 'general',
+      });
+      expect(mockClient.conversations.info).toHaveBeenCalledWith({
+        channel: 'C123',
+      });
     });
   });
 });

--- a/tests/utils/slack-operations/file-operations.test.ts
+++ b/tests/utils/slack-operations/file-operations.test.ts
@@ -286,5 +286,155 @@ describe('FileOperations', () => {
         'Slack returned HTML instead of the file'
       );
     });
+
+    it('should reject missing file metadata and missing download URLs', async () => {
+      mockClient.files.info.mockResolvedValueOnce({});
+
+      await expect(fileOps.downloadFile({ fileId: 'missing' })).rejects.toThrow(
+        'Slack file not found: missing'
+      );
+
+      mockClient.files.info.mockResolvedValueOnce({
+        file: { id: 'F123', name: 'image.png' },
+      });
+
+      await expect(fileOps.downloadFile({ fileId: 'F123' })).rejects.toThrow(
+        'Selected Slack file does not include a private download URL'
+      );
+    });
+
+    it('should reject non-successful file download responses', async () => {
+      mockClient.files.info.mockResolvedValue({
+        file: {
+          id: 'F123',
+          name: 'image.png',
+          url_private: 'https://files.slack.com/files-pri/T123-F123/image.png',
+        },
+      });
+      fetchMock.mockResolvedValueOnce(
+        new Response('missing', {
+          status: 404,
+          statusText: 'Not Found',
+        })
+      );
+
+      await expect(fileOps.downloadFile({ fileId: 'F123' })).rejects.toThrow(
+        'Failed to download Slack file: 404 Not Found'
+      );
+    });
+
+    it('should validate message file selection inputs', async () => {
+      await expect(fileOps.downloadFile({ messageTs: '1.2' })).rejects.toThrow(
+        'Channel and message timestamp are required'
+      );
+
+      vi.mocked(channelResolver.resolveChannelId).mockResolvedValue('C123456789');
+      mockClient.conversations.history.mockResolvedValueOnce({
+        messages: [{ type: 'message', ts: '1.2', files: [] }],
+      });
+
+      await expect(fileOps.downloadFile({ channel: 'general', messageTs: '1.2' })).rejects.toThrow(
+        'No files found on message 1.2'
+      );
+
+      mockClient.conversations.history.mockResolvedValueOnce({
+        messages: [
+          {
+            type: 'message',
+            ts: '1.2',
+            files: [
+              {
+                id: 'F123',
+                name: 'image.png',
+                url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+              },
+            ],
+          },
+        ],
+      });
+
+      await expect(
+        fileOps.downloadFile({ channel: 'general', messageTs: '1.2', fileIndex: 2 })
+      ).rejects.toThrow('File index 2 is out of range');
+    });
+
+    it('should require a token before downloading private files', async () => {
+      mockClient.files.info.mockResolvedValue({
+        file: {
+          id: 'F123',
+          name: 'image.png',
+          url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+        },
+      });
+      (fileOps as unknown as { token?: string }).token = undefined;
+
+      await expect(fileOps.downloadFile({ fileId: 'F123' })).rejects.toThrow(
+        'Slack token is required to download private files'
+      );
+    });
+
+    it('should follow redirects and stop sending Slack auth off-domain', async () => {
+      mockClient.files.info.mockResolvedValue({
+        file: {
+          id: 'F123',
+          name: 'image.png',
+          url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+        },
+      });
+      fetchMock
+        .mockResolvedValueOnce(
+          new Response(null, {
+            status: 302,
+            headers: { location: 'https://downloads.example.com/image.png' },
+          })
+        )
+        .mockResolvedValueOnce(
+          new Response(Buffer.from('redirected'), {
+            status: 200,
+            headers: { 'content-type': 'image/png' },
+          })
+        );
+
+      await expect(
+        fileOps.downloadFile({ fileId: 'F123', outputPath: '/tmp/image.png' })
+      ).resolves.toMatchObject({ bytes: 10 });
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        'https://files.slack.com/files-pri/T123-F123/image.png',
+        {
+          headers: { Authorization: 'Bearer test-token' },
+          redirect: 'manual',
+        }
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://downloads.example.com/image.png', {
+        headers: undefined,
+        redirect: 'manual',
+      });
+    });
+
+    it('should reject redirects without a location or with too many hops', async () => {
+      mockClient.files.info.mockResolvedValue({
+        file: {
+          id: 'F123',
+          name: 'image.png',
+          url_private_download: 'https://files.slack.com/files-pri/T123-F123/image.png',
+        },
+      });
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 302 }));
+
+      await expect(fileOps.downloadFile({ fileId: 'F123' })).rejects.toThrow(
+        'redirected without a Location header'
+      );
+
+      fetchMock.mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: { location: '/next' },
+        })
+      );
+
+      await expect(fileOps.downloadFile({ fileId: 'F123' })).rejects.toThrow('Too many redirects');
+    });
   });
 });

--- a/tests/utils/slack-operations/message-write-operations.test.ts
+++ b/tests/utils/slack-operations/message-write-operations.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageWriteOperations } from '../../../src/utils/slack-operations/message-write-operations';
+
+vi.mock('@slack/web-api', () => ({
+  LogLevel: { ERROR: 'error' },
+  WebClient: vi.fn().mockImplementation(function () {
+    return {
+      chat: {
+        delete: vi.fn(),
+        deleteScheduledMessage: vi.fn(),
+        postEphemeral: vi.fn(),
+        postMessage: vi.fn(),
+        scheduleMessage: vi.fn(),
+        scheduledMessages: {
+          list: vi.fn(),
+        },
+        update: vi.fn(),
+      },
+    };
+  }),
+}));
+
+describe('MessageWriteOperations', () => {
+  type MockClient = {
+    chat: {
+      delete: ReturnType<typeof vi.fn>;
+      deleteScheduledMessage: ReturnType<typeof vi.fn>;
+      postEphemeral: ReturnType<typeof vi.fn>;
+      postMessage: ReturnType<typeof vi.fn>;
+      scheduleMessage: ReturnType<typeof vi.fn>;
+      scheduledMessages: {
+        list: ReturnType<typeof vi.fn>;
+      };
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  let messageOps: MessageWriteOperations;
+  let mockClient: MockClient;
+  let channelOps: { resolveChannelId: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    channelOps = { resolveChannelId: vi.fn().mockResolvedValue('C1234567890') };
+    messageOps = new MessageWriteOperations('test-token', channelOps as never);
+    mockClient = (messageOps as unknown as { client: MockClient }).client;
+  });
+
+  it('sends regular and threaded messages', async () => {
+    mockClient.chat.postMessage.mockResolvedValue({ ok: true, ts: '1.2' });
+
+    await expect(messageOps.sendMessage('C1', 'hello')).resolves.toEqual({ ok: true, ts: '1.2' });
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith({
+      channel: 'C1',
+      text: 'hello',
+    });
+
+    await messageOps.sendMessage('C1', 'reply', '1.2');
+    expect(mockClient.chat.postMessage).toHaveBeenLastCalledWith({
+      channel: 'C1',
+      text: 'reply',
+      thread_ts: '1.2',
+    });
+  });
+
+  it('sends regular and threaded ephemeral messages', async () => {
+    mockClient.chat.postEphemeral.mockResolvedValue({ ok: true });
+
+    await messageOps.sendEphemeralMessage('C1', 'U1', 'hello');
+    expect(mockClient.chat.postEphemeral).toHaveBeenCalledWith({
+      channel: 'C1',
+      user: 'U1',
+      text: 'hello',
+    });
+
+    await messageOps.sendEphemeralMessage('C1', 'U1', 'reply', '1.2');
+    expect(mockClient.chat.postEphemeral).toHaveBeenLastCalledWith({
+      channel: 'C1',
+      user: 'U1',
+      text: 'reply',
+      thread_ts: '1.2',
+    });
+  });
+
+  it('schedules regular and threaded messages', async () => {
+    mockClient.chat.scheduleMessage.mockResolvedValue({ ok: true, scheduled_message_id: 'Q1' });
+
+    await messageOps.scheduleMessage('C1', 'later', 123);
+    expect(mockClient.chat.scheduleMessage).toHaveBeenCalledWith({
+      channel: 'C1',
+      text: 'later',
+      post_at: 123,
+    });
+
+    await messageOps.scheduleMessage('C1', 'thread later', 123, '1.2');
+    expect(mockClient.chat.scheduleMessage).toHaveBeenLastCalledWith({
+      channel: 'C1',
+      text: 'thread later',
+      post_at: 123,
+      thread_ts: '1.2',
+    });
+  });
+
+  it('lists scheduled messages with and without a channel filter', async () => {
+    mockClient.chat.scheduledMessages.list.mockResolvedValueOnce({
+      scheduled_messages: [{ id: 'Q1' }],
+    });
+
+    await expect(messageOps.listScheduledMessages(undefined, 20)).resolves.toEqual([{ id: 'Q1' }]);
+    expect(mockClient.chat.scheduledMessages.list).toHaveBeenCalledWith({ limit: 20 });
+
+    mockClient.chat.scheduledMessages.list.mockResolvedValueOnce({});
+
+    await expect(messageOps.listScheduledMessages('general')).resolves.toEqual([]);
+    expect(channelOps.resolveChannelId).toHaveBeenCalledWith('general');
+    expect(mockClient.chat.scheduledMessages.list).toHaveBeenLastCalledWith({
+      limit: 50,
+      channel: 'C1234567890',
+    });
+  });
+
+  it('resolves channel names before mutating existing messages', async () => {
+    mockClient.chat.update.mockResolvedValue({ ok: true, ts: '1.2' });
+
+    await expect(messageOps.updateMessage('general', '1.2', 'updated')).resolves.toEqual({
+      ok: true,
+      ts: '1.2',
+    });
+    expect(mockClient.chat.update).toHaveBeenCalledWith({
+      channel: 'C1234567890',
+      ts: '1.2',
+      text: 'updated',
+    });
+
+    await messageOps.deleteMessage('general', '1.2');
+    expect(mockClient.chat.delete).toHaveBeenCalledWith({
+      channel: 'C1234567890',
+      ts: '1.2',
+    });
+
+    await messageOps.cancelScheduledMessage('general', 'Q1');
+    expect(mockClient.chat.deleteScheduledMessage).toHaveBeenCalledWith({
+      channel: 'C1234567890',
+      scheduled_message_id: 'Q1',
+    });
+  });
+});

--- a/tests/utils/slack-table-blocks.test.ts
+++ b/tests/utils/slack-table-blocks.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Message } from '../../src/types/slack';
+import {
+  displaySlackTables,
+  extractSlackTables,
+  parseTableOutputFormat,
+} from '../../src/utils/slack-table-blocks';
+
+const messagesWithTables = [
+  {
+    ts: '1000.000001',
+    blocks: [
+      {
+        type: 'table',
+        rows: [
+          [
+            { type: 'raw_text', text: 'Name' },
+            { type: 'raw_number', value: 42 },
+          ],
+          [
+            {
+              type: 'rich_text',
+              elements: [
+                { text: 'hello ' },
+                { type: 'link', url: 'https://example.com' },
+                { type: 'user', user_id: 'U123' },
+                { type: 'emoji', name: 'wave' },
+              ],
+            },
+            { type: 'unknown' },
+          ],
+        ],
+      },
+      { type: 'section', text: { text: 'ignored' } },
+    ],
+    attachments: [
+      {
+        blocks: [
+          {
+            type: 'table',
+            rows: [[{ type: 'raw_text', text: 'Attachment\ncell|value\tend' }]],
+          },
+        ],
+      },
+    ],
+  },
+] as Message[];
+
+describe('slack-table-blocks', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('extracts table rows from message blocks and attachment blocks', () => {
+    expect(extractSlackTables(messagesWithTables)).toEqual([
+      {
+        messageTs: '1000.000001',
+        tableIndex: 0,
+        rows: [
+          ['Name', '42'],
+          ['hello https://example.com<@U123>:wave:', ''],
+        ],
+      },
+      {
+        messageTs: '1000.000001',
+        tableIndex: 1,
+        rows: [['Attachment\ncell|value\tend']],
+      },
+    ]);
+  });
+
+  it('ignores malformed table-like blocks', () => {
+    expect(
+      extractSlackTables([
+        { ts: '1', blocks: [{ type: 'table', rows: ['not-row'] }] },
+        { ts: '2', attachments: [{ blocks: [{ type: 'table' }] }] },
+      ] as Message[])
+    ).toEqual([]);
+  });
+
+  it('displays markdown, TSV, JSON, and no-table output', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    displaySlackTables(messagesWithTables, 'markdown');
+    expect(logSpy).toHaveBeenCalledWith('| Name | 42 |');
+    expect(logSpy).toHaveBeenCalledWith('| --- | --- |');
+    expect(logSpy).toHaveBeenCalledWith('| Attachment cell\\|value\tend |');
+
+    logSpy.mockClear();
+    displaySlackTables(messagesWithTables, 'tsv');
+    expect(logSpy).toHaveBeenCalledWith('Name\t42');
+    expect(logSpy).toHaveBeenCalledWith('Attachment cell|value end');
+
+    logSpy.mockClear();
+    displaySlackTables(messagesWithTables, 'json');
+    const parsed = JSON.parse(logSpy.mock.calls[0][0]);
+    expect(parsed.total).toBe(2);
+    expect(parsed.tables[0]).toMatchObject({
+      message_ts: '1000.000001',
+      index: 0,
+    });
+
+    logSpy.mockClear();
+    displaySlackTables([{ ts: '3', text: 'plain' }] as Message[], 'markdown');
+    expect(logSpy).toHaveBeenCalledWith('No tables found');
+  });
+
+  it('parses output format options', () => {
+    expect(parseTableOutputFormat()).toBe('markdown');
+    expect(parseTableOutputFormat('markdown')).toBe('markdown');
+    expect(parseTableOutputFormat('json')).toBe('json');
+    expect(parseTableOutputFormat('tsv')).toBe('tsv');
+    expect(() => parseTableOutputFormat('csv')).toThrow('Invalid table format');
+  });
+});

--- a/tests/utils/token-crypto-service.test.ts
+++ b/tests/utils/token-crypto-service.test.ts
@@ -2,7 +2,7 @@ import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConfigurationError, ValidationError } from '../../src/utils/errors';
 import { TokenCryptoService } from '../../src/utils/token-crypto-service';
 
@@ -28,6 +28,7 @@ describe('TokenCryptoService', () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     if (originalMasterKey === undefined) {
       delete process.env.SLACK_CLI_MASTER_KEY;
     } else {
@@ -197,6 +198,89 @@ describe('TokenCryptoService', () => {
         }
       }
     });
+
+    it('should use an injected master key without reading key files', () => {
+      delete process.env.SLACK_CLI_MASTER_KEY;
+      const injectedService = new TokenCryptoService({ masterKey: 'injected-master-key' });
+
+      const encrypted = injectedService.encrypt('injected-token');
+
+      expect(injectedService.decrypt(encrypted)).toBe('injected-token');
+    });
+
+    it('should fail clearly when a new key file cannot be initialized', () => {
+      let tempDir: string | undefined;
+
+      try {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-cli-key-init-fail-'));
+        const blockingFilePath = path.join(tempDir, 'secrets');
+        const newKeyFilePath = path.join(blockingFilePath, 'master.key');
+        const legacyKeyFilePath = path.join(tempDir, 'config', 'master.key');
+
+        delete process.env.SLACK_CLI_MASTER_KEY;
+        fs.writeFileSync(blockingFilePath, 'not a directory');
+
+        const failingService = new TokenCryptoService({
+          keyFilePath: newKeyFilePath,
+          legacyKeyFilePath,
+        });
+
+        expect(() => failingService.encrypt('token')).toThrow('Failed to encrypt token');
+      } finally {
+        if (tempDir) {
+          fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
+    });
+
+    it('should fail clearly when legacy key migration cannot read a usable legacy key', () => {
+      let tempDir: string | undefined;
+
+      try {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-cli-key-migrate-fail-'));
+        const newKeyFilePath = path.join(tempDir, 'secrets', 'master.key');
+        const legacyKeyFilePath = path.join(tempDir, 'config', 'master.key');
+
+        delete process.env.SLACK_CLI_MASTER_KEY;
+        fs.mkdirSync(path.dirname(legacyKeyFilePath), { recursive: true });
+        fs.writeFileSync(legacyKeyFilePath, 'not-a-hex-key\n');
+
+        const migratedService = new TokenCryptoService({
+          keyFilePath: newKeyFilePath,
+          legacyKeyFilePath,
+        });
+
+        expect(() => migratedService.encrypt('token')).toThrow('Failed to encrypt token');
+      } finally {
+        if (tempDir) {
+          fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
+    });
+
+    it('should fail clearly when the configured key file cannot be loaded', () => {
+      let tempDir: string | undefined;
+
+      try {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'slack-cli-key-load-fail-'));
+        const newKeyFilePath = path.join(tempDir, 'secrets', 'master.key');
+        const legacyKeyFilePath = path.join(tempDir, 'config', 'master.key');
+
+        delete process.env.SLACK_CLI_MASTER_KEY;
+        fs.mkdirSync(newKeyFilePath, { recursive: true });
+
+        const fileKeyService = new TokenCryptoService({
+          keyFilePath: newKeyFilePath,
+          legacyKeyFilePath,
+        });
+
+        expect(() => fileKeyService.encrypt('token')).toThrow('Failed to encrypt token');
+      } finally {
+        if (tempDir) {
+          fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+      }
+    });
   });
 
   describe('decrypt error handling', () => {
@@ -255,6 +339,19 @@ describe('TokenCryptoService', () => {
         expect((error as ConfigurationError).code).toBe('CONFIGURATION_ERROR');
         expect((error as ConfigurationError).message).toBe('Failed to decrypt token');
       }
+    });
+
+    it('should reject invalid data passed directly to format-specific decryptors', () => {
+      expect(() =>
+        (
+          service as unknown as { decryptCurrentFormat: (value: string) => string }
+        ).decryptCurrentFormat('invalid')
+      ).toThrow(ValidationError);
+      expect(() =>
+        (
+          service as unknown as { decryptLegacyFormat: (value: string) => string }
+        ).decryptLegacyFormat('invalid')
+      ).toThrow(ValidationError);
     });
   });
 

--- a/tests/utils/update-notifier.test.ts
+++ b/tests/utils/update-notifier.test.ts
@@ -141,6 +141,83 @@ describe('update notifier', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
+  it('invalid cache entries are treated as cache misses', async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify({ latestVersion: 123 }));
+
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '1.0.1' }),
+    });
+
+    await checkForUpdates({
+      packageName: '@urugus/slack-cli',
+      currentVersion: '1.0.0',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fetchImpl).toHaveBeenCalled();
+    expect(fs.rename).toHaveBeenCalled();
+  });
+
+  it('cache read errors other than missing files are swallowed', async () => {
+    vi.mocked(fs.readFile).mockRejectedValue(
+      Object.assign(new Error('denied'), { code: 'EACCES' })
+    );
+    const fetchImpl = vi.fn();
+
+    await checkForUpdates({
+      packageName: '@urugus/slack-cli',
+      currentVersion: '1.0.0',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('registry error responses and invalid payloads are swallowed', async () => {
+    vi.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
+
+    await checkForUpdates({
+      packageName: '@urugus/slack-cli',
+      currentVersion: '1.0.0',
+      fetchImpl: vi.fn().mockResolvedValue({ ok: false, status: 500 }) as unknown as typeof fetch,
+    });
+
+    await checkForUpdates({
+      packageName: '@urugus/slack-cli',
+      currentVersion: '1.0.0',
+      fetchImpl: vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: '' }),
+      }) as unknown as typeof fetch,
+    });
+
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('cleans up temp cache files when atomic rename fails', async () => {
+    vi.mocked(fs.readFile).mockRejectedValue({ code: 'ENOENT' });
+    vi.mocked(fs.rename).mockRejectedValue(new Error('rename failed'));
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: '1.0.1' }),
+    });
+
+    await checkForUpdates({
+      packageName: '@urugus/slack-cli',
+      currentVersion: '1.0.0',
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(fs.unlink).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^\/home\/test-user\/\.slack-cli\/update-notifier\.json\.\d+\.\d+\.tmp$/
+      )
+    );
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
   it('CI environment skips update checks', async () => {
     process.env.CI = '1';
     const fetchImpl = vi.fn();


### PR DESCRIPTION
# 背景

- テストカバレッジを最大限高めるため、未カバーの helper、facade、Slack operation、CLI 異常系を重点的に固定します。

# 概要

- Dependabot リスク判定、history validator、SlackApiClient facade、Slack table block、channel formatter、constants、base client、message write/canvas/channel/file operations のテストを追加しました。
- status/config/update notifier/token crypto の異常系テストを拡充しました。
- `mapChannelToInfo` が `created` 欠落時に落ちる問題を修正しました。
- `package.json` / `package-lock.json` を `0.25.1` に bump しました。

# 関連情報

- Jira issue: なし

# 確認方法

- `npm run check`
- `npm run build`
- `npm test`
- `npm run test:coverage`

最終カバレッジ:

- Statements: 96.35%
- Branches: 83.76%
- Functions: 97.42%
- Lines: 96.43%
