### PR TITLE
status keep-alive に loading message file を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working
 # Keep status alive with dynamic status text from a file
 slack-cli status keep-alive -c channel-name -t 1719207629.000100 --text "Working on it" \
   --text-file /tmp/slack-cli-status.txt \
+  --loading-message-file /tmp/slack-cli-loading-message.txt \
   --interval 80 \
   --max-duration 600 \
   --stop-file /tmp/slack-cli-status.stop
@@ -517,6 +518,11 @@ file content overrides `--text`; missing, empty, or unreadable files fall back t
 When the resolved text changes, keep-alive sends the new status immediately instead of waiting
 for the next `--interval` refresh.
 
+With `--loading-message-file`, the CLI reads a loading message from the file on each refresh.
+Non-empty file content is sent as one `loading_messages` entry and overrides any
+`--loading-message` arguments. Missing, empty, or unreadable files fall back to the repeatable
+`--loading-message` values.
+
 With `--detach`, the CLI starts the same keep-alive command in a detached child process without
 `--detach`, writes the child PID to `--pid-file`, and exits immediately. Without `--detach`,
 `--pid-file` writes the foreground process PID and is removed when keep-alive exits.
@@ -527,20 +533,21 @@ each `setStatus` success or failure with the error message, status text changes 
 `--detach` runs stay traceable even though the child runs with `stdio: 'ignore'`. Log writes are
 best-effort and never interrupt keep-alive.
 
-| Option            | Short | Description                                           |
-| ----------------- | ----- | ----------------------------------------------------- |
-| --channel         | -c    | Target channel name or ID (required)                  |
-| --thread          | -t    | Thread parent timestamp (required)                    |
-| --text            |       | Status text (required)                                |
-| --text-file       |       | Read dynamic status text from this file               |
-| --interval        |       | Refresh interval in seconds (default: 80)             |
-| --max-duration    |       | Maximum duration in seconds (default: 600)            |
-| --stop-file       |       | Stop when this path exists                            |
-| --detach          |       | Run keep-alive in a detached background process       |
-| --pid-file        |       | Write the keep-alive process ID to this file          |
-| --log-file        |       | Append timestamped activity logs to this file         |
-| --loading-message |       | Optional loading message; repeatable up to 10         |
-| --profile         |       | Use specific workspace profile                        |
+| Option                 | Short | Description                                           |
+| ---------------------- | ----- | ----------------------------------------------------- |
+| --channel              | -c    | Target channel name or ID (required)                  |
+| --thread               | -t    | Thread parent timestamp (required)                    |
+| --text                 |       | Status text (required)                                |
+| --text-file            |       | Read dynamic status text from this file               |
+| --interval             |       | Refresh interval in seconds (default: 80)             |
+| --max-duration         |       | Maximum duration in seconds (default: 600)            |
+| --stop-file            |       | Stop when this path exists                            |
+| --detach               |       | Run keep-alive in a detached background process       |
+| --pid-file             |       | Write the keep-alive process ID to this file          |
+| --log-file             |       | Append timestamped activity logs to this file         |
+| --loading-message      |       | Optional loading message; repeatable up to 10         |
+| --loading-message-file |       | Read dynamic loading message from this file           |
+| --profile              |       | Use specific workspace profile                        |
 
 #### status stop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.25.1",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -34,6 +34,7 @@ type StatusCommandOptions = {
   pidFile?: string;
   logFile?: string;
   loadingMessage?: string[];
+  loadingMessageFile?: string;
 };
 
 function collectLoadingMessage(value: string, previous: string[] = []): string[] {
@@ -175,6 +176,11 @@ function warn(message: string): void {
 
 type KeepAliveLogger = (message: string) => void;
 
+type OptionalFileContent =
+  | { kind: 'absent' }
+  | { kind: 'readable'; content: string }
+  | { kind: 'unreadable'; error: unknown };
+
 function createKeepAliveLogger(logFile: string | undefined): KeepAliveLogger {
   if (!logFile) {
     return () => {
@@ -202,21 +208,46 @@ function createKeepAliveLogger(logFile: string | undefined): KeepAliveLogger {
   };
 }
 
-function resolveStatusText(text: string, textFile: string | undefined): string {
-  if (!textFile) {
-    return text;
+function readOptionalFileContent(filePath: string | undefined): OptionalFileContent {
+  if (!filePath || !fs.existsSync(filePath)) {
+    return { kind: 'absent' };
   }
 
   try {
-    const content = fs.readFileSync(textFile, 'utf8').trim();
-    if (content === '') {
-      return text;
-    }
+    return { kind: 'readable', content: fs.readFileSync(filePath, 'utf8') };
+  } catch (error) {
+    return { kind: 'unreadable', error };
+  }
+}
 
-    return content.replace(/[\r\n]+/g, '');
-  } catch {
+function normalizeFileBackedStatusValue(content: string): string {
+  return content.trim().replace(/[\r\n]+/g, '');
+}
+
+function readableFileContent(fileContent: OptionalFileContent): string | undefined {
+  return fileContent.kind === 'readable' ? fileContent.content : undefined;
+}
+
+function resolveLoadingMessages(
+  loadingMessages: string[] | undefined,
+  loadingMessageFileContent: string | undefined
+): string[] {
+  const fallback = loadingMessages ?? [];
+  if (loadingMessageFileContent === undefined) {
+    return fallback;
+  }
+
+  const content = normalizeFileBackedStatusValue(loadingMessageFileContent);
+  return content === '' ? fallback : [content];
+}
+
+function resolveStatusText(text: string, textFileContent: string | undefined): string {
+  if (textFileContent === undefined) {
     return text;
   }
+
+  const content = normalizeFileBackedStatusValue(textFileContent);
+  return content === '' ? text : content;
 }
 
 async function clearStatusIgnoringErrors(
@@ -379,13 +410,27 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   };
 
   const setCurrentStatus = async (): Promise<void> => {
-    const status = resolveStatusText(options.text, options.textFile);
+    const textFileContent = readOptionalFileContent(options.textFile);
+    const loadingMessageFileContent = readOptionalFileContent(options.loadingMessageFile);
+    if (options.loadingMessageFile && loadingMessageFileContent.kind === 'unreadable') {
+      log(
+        `failed to read loading-message-file ${options.loadingMessageFile}: ${extractErrorMessage(
+          loadingMessageFileContent.error
+        )}`
+      );
+    }
+
+    const status = resolveStatusText(options.text, readableFileContent(textFileContent));
+    const loadingMessages = resolveLoadingMessages(
+      options.loadingMessage,
+      readableFileContent(loadingMessageFileContent)
+    );
     try {
       await client.setAssistantThreadStatus({
         channel: options.channel,
         threadTs: options.thread,
         status,
-        loadingMessages: options.loadingMessage,
+        loadingMessages,
       });
       lastSentStatus = status;
       log(`setStatus succeeded: "${status}"`);
@@ -396,7 +441,8 @@ async function runKeepAlive(options: StatusKeepAliveOptions): Promise<void> {
   };
 
   const resendIfStatusTextChanged = async (): Promise<void> => {
-    const status = resolveStatusText(options.text, options.textFile);
+    const textFileContent = readOptionalFileContent(options.textFile);
+    const status = resolveStatusText(options.text, readableFileContent(textFileContent));
     if (status === lastSentStatus) {
       return;
     }
@@ -601,6 +647,10 @@ export function setupStatusCommand(): Command {
       DEFAULT_KEEP_ALIVE_MAX_DURATION_SECONDS.toString()
     )
     .option('--stop-file <path>', 'Stop when this file exists')
+    .option(
+      '--loading-message-file <path>',
+      'Read loading message from this file with --loading-message as fallback'
+    )
     .option(
       '--loading-message <message>',
       'Loading message shown by Slack; can be specified up to 10 times',

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -209,13 +209,17 @@ function createKeepAliveLogger(logFile: string | undefined): KeepAliveLogger {
 }
 
 function readOptionalFileContent(filePath: string | undefined): OptionalFileContent {
-  if (!filePath || !fs.existsSync(filePath)) {
+  if (!filePath) {
     return { kind: 'absent' };
   }
 
   try {
     return { kind: 'readable', content: fs.readFileSync(filePath, 'utf8') };
   } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') {
+      return { kind: 'absent' };
+    }
+
     return { kind: 'unreadable', error };
   }
 }

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -53,6 +53,7 @@ export interface StatusKeepAliveOptions {
   pidFile?: string;
   logFile?: string;
   loadingMessage?: string[];
+  loadingMessageFile?: string;
   profile?: string;
 }
 

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -413,6 +413,146 @@ describe('status command', () => {
       await keepAlivePromise;
     });
 
+    it('should use loading-message-file content as one loading message on each refresh', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const loadingMessageFile = tempPath('loading-message.txt');
+      fs.writeFileSync(loadingMessageFile, 'Phase 1\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--loading-message-file',
+        loadingMessageFile,
+        '--interval',
+        '5',
+        '--max-duration',
+        '6',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenLastCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['Phase 1'],
+      });
+
+      fs.writeFileSync(loadingMessageFile, 'Phase 2\n');
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenLastCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['Phase 2'],
+      });
+
+      await vi.advanceTimersByTimeAsync(1000);
+      await keepAlivePromise;
+      fs.unlinkSync(loadingMessageFile);
+    });
+
+    it('should fall back to loading-message arguments when loading-message-file is empty', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const loadingMessageFile = tempPath('empty-loading-message.txt');
+      fs.writeFileSync(loadingMessageFile, '\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--loading-message',
+        'Fallback 1',
+        '--loading-message',
+        'Fallback 2',
+        '--loading-message-file',
+        loadingMessageFile,
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['Fallback 1', 'Fallback 2'],
+      });
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+      fs.unlinkSync(loadingMessageFile);
+    });
+
+    it('should prefer loading-message-file over multiple loading-message arguments', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const loadingMessageFile = tempPath('override-loading-message.txt');
+      fs.writeFileSync(loadingMessageFile, 'File phase\n');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--loading-message',
+        'Fallback 1',
+        '--loading-message',
+        'Fallback 2',
+        '--loading-message-file',
+        loadingMessageFile,
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['File phase'],
+      });
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+      fs.unlinkSync(loadingMessageFile);
+    });
+
     it('should spawn a detached copy without --detach and write child pid', async () => {
       const pidFile = tempPath('detached.pid');
       const originalArgv = process.argv;
@@ -777,6 +917,56 @@ describe('status command', () => {
 
       expect(content).toContain('setStatus failed: timeout');
       expect(content).toContain('setStatus succeeded: "Working"');
+    });
+
+    it('should log loading-message-file read failures and continue with fallback messages', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const loadingMessageFile = tempPath('loading-message-dir');
+      const logFile = tempPath('loading-message-read-failure.log');
+      fs.mkdirSync(loadingMessageFile);
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--loading-message',
+        'Fallback',
+        '--loading-message-file',
+        loadingMessageFile,
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+        '--log-file',
+        logFile,
+      ]);
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['Fallback'],
+      });
+
+      const content = fs.readFileSync(logFile, 'utf8');
+      fs.rmSync(loadingMessageFile, { recursive: true, force: true });
+      fs.unlinkSync(logFile);
+
+      expect(content).toContain('failed to read loading-message-file');
     });
 
     it('should log stop-file detection as the stop reason', async () => {

--- a/tests/commands/status.test.ts
+++ b/tests/commands/status.test.ts
@@ -508,6 +508,47 @@ describe('status command', () => {
       fs.unlinkSync(loadingMessageFile);
     });
 
+    it('should fall back to loading-message arguments when loading-message-file is missing', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));
+      mockConfiguredClient();
+      vi.mocked(mockSlackClient.setAssistantThreadStatus).mockResolvedValue({ ok: true });
+      vi.mocked(mockSlackClient.clearAssistantThreadStatus).mockResolvedValue({ ok: true });
+      const loadingMessageFile = tempPath('missing-loading-message.txt');
+
+      const keepAlivePromise = program.parseAsync([
+        'node',
+        'slack-cli',
+        'status',
+        'keep-alive',
+        '-c',
+        'general',
+        '-t',
+        '1234567890.123456',
+        '--text',
+        'Working',
+        '--loading-message',
+        'Fallback',
+        '--loading-message-file',
+        loadingMessageFile,
+        '--interval',
+        '5',
+        '--max-duration',
+        '5',
+      ]);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(mockSlackClient.setAssistantThreadStatus).toHaveBeenCalledWith({
+        channel: 'general',
+        threadTs: '1234567890.123456',
+        status: 'Working',
+        loadingMessages: ['Fallback'],
+      });
+
+      await vi.advanceTimersByTimeAsync(5000);
+      await keepAlivePromise;
+    });
+
     it('should prefer loading-message-file over multiple loading-message arguments', async () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date('2026-03-05T00:00:00Z'));


### PR DESCRIPTION
# 背景

- `status keep-alive` でステータス本文は `--text-file` により動的更新できる一方、Slack の loading message は起動時の `--loading-message` 指定に固定されていました。

# 概要

- `status keep-alive` に `--loading-message-file` を追加しました。
- ファイル内容が非空の場合は、1件の `loading_messages` として送信します。
- ファイルが未指定・未存在・空・読み込み不可の場合は、既存の `--loading-message` 指定にフォールバックします。
- ファイル読み込みと解決ロジックを分離し、`resolveStatusText` / `resolveLoadingMessages` は純粋関数として扱える形に整理しました。
- README と型定義、関連テスト、package version を更新しました。

# 確認方法

- `npm run check`
- `npm test -- --run`
- `npm run build`
