### PR TITLE
npm supply chain metadata を改善

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -56,6 +57,6 @@ jobs:
 
       - name: Publish to npm
         if: steps.check_tag.outputs.exists == 'false'
-        run: npm publish
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.26.0",
+      "version": "0.26.1",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {
@@ -23,6 +23,14 @@
     "prepublishOnly": "npm run build"
   },
   "keywords": ["slack", "cli", "command-line", "messaging", "api"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/urugus/slack-cli.git"
+  },
+  "bugs": {
+    "url": "https://github.com/urugus/slack-cli/issues"
+  },
+  "homepage": "https://github.com/urugus/slack-cli#readme",
   "author": "urugus",
   "publishConfig": {
     "access": "public"

--- a/tests/package-security-metadata.test.ts
+++ b/tests/package-security-metadata.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const packageJson = JSON.parse(readFileSync('package.json', 'utf8'));
+const releaseWorkflow = readFileSync('.github/workflows/release.yml', 'utf8');
+
+describe('package supply-chain metadata', () => {
+  it('links published package metadata back to the source repository', () => {
+    expect(packageJson.repository).toEqual({
+      type: 'git',
+      url: 'git+https://github.com/urugus/slack-cli.git',
+    });
+    expect(packageJson.bugs).toEqual({
+      url: 'https://github.com/urugus/slack-cli/issues',
+    });
+    expect(packageJson.homepage).toBe('https://github.com/urugus/slack-cli#readme');
+  });
+
+  it('publishes npm releases with provenance from GitHub Actions', () => {
+    expect(releaseWorkflow).toMatch(/id-token:\s*write/);
+    expect(releaseWorkflow).toMatch(/npm publish --provenance/);
+  });
+});


### PR DESCRIPTION
# 背景

- Socket.dev の Supply Chain Security スコア改善に向けて、npm 公開メタデータと publish provenance 設定を整備します。

# 概要

- package.json に repository / bugs / homepage を追加し、公開パッケージから GitHub repository へ辿れるようにしました。
- release workflow に id-token: write を追加し、npm publish --provenance で provenance attestation を生成できるようにしました。
- supply-chain metadata の退行防止テストを追加しました。
- package.json / package-lock.json を 0.26.1 に patch bump しました。

# 関連情報

- Socket package: https://socket.dev/npm/package/%40urugus%2Fslack-cli

# 確認方法

- npm test -- tests/package-security-metadata.test.ts
- npm run check
- npm run build
- npm test
- npm run test:coverage
