### PR TITLE
sendコマンドにBlock Kit送信を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Add Block Kit message support to `slack-cli send` with `--blocks` and `--blocks-file`
 
+## [0.26.1] - 2026-06-18
+
+### Changed
+- Improve npm supply chain metadata and release provenance settings
+
+## [0.26.0] - 2026-06-18
+
+### Added
+- Add `status keep-alive --loading-message-file` for dynamic rotating loading messages
+
 ## [0.25.1] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0] - 2026-06-19
+
+### Added
+- Add Block Kit message support to `slack-cli send` with `--blocks` and `--blocks-file`
+
 ## [0.25.1] - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ slack-cli send --user @john -m "Hello via DM!"
 
 # Send DM by email
 slack-cli send --email john@example.com -m "Hello via DM!"
+
+# Send Block Kit blocks
+slack-cli send -c general --blocks '[{"type":"divider"}]'
+
+# Send Block Kit blocks from a file
+slack-cli send -c general --blocks-file ./blocks.json -m "fallback"
 ```
 
 ### Assistant Thread Status
@@ -480,6 +486,8 @@ slack-cli send -c general -t 1234567890.123456 --blocks '[{"type":"divider"}]'
 ```
 
 - `--blocks` と `--blocks-file` は排他
+- `-m` / `-f` は blocks と併用すると通知用 fallback text として送信される
+- `-m` / `-f` なしでも blocks のみ送信できる
 - blocks は「`type` を持つ object の JSON 配列」であることを送信前に検証する
 
 
@@ -808,4 +816,3 @@ Messages sent via the `send` command automatically support Slack's mrkdwn format
 ## License
 
 MIT
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.26.1",
+      "version": "0.27.0",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.26.1",
+  "version": "0.27.0",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -127,17 +127,13 @@ export function setupSendCommand(): Command {
         }
 
         if (postAt !== null) {
-          if (blocks) {
-            await client.scheduleMessage(
-              targetChannel,
-              messageContent,
-              postAt,
-              options.thread,
-              blocks
-            );
-          } else {
-            await client.scheduleMessage(targetChannel, messageContent, postAt, options.thread);
-          }
+          await client.scheduleMessage(
+            targetChannel,
+            messageContent,
+            postAt,
+            options.thread,
+            blocks
+          );
           const postAtIso = new Date(postAt * 1000).toISOString();
           if (options.user || options.email) {
             console.log(chalk.green(`✓ Message scheduled to ${targetLabel} at ${postAtIso}`));
@@ -149,11 +145,7 @@ export function setupSendCommand(): Command {
           return;
         }
 
-        if (blocks) {
-          await client.sendMessage(targetChannel, messageContent, options.thread, blocks);
-        } else {
-          await client.sendMessage(targetChannel, messageContent, options.thread);
-        }
+        await client.sendMessage(targetChannel, messageContent, options.thread, blocks);
         if (options.user || options.email) {
           console.log(chalk.green(`✓ DM sent to ${targetLabel}`));
         } else {

--- a/src/commands/send.ts
+++ b/src/commands/send.ts
@@ -2,14 +2,66 @@ import chalk from 'chalk';
 import { Command } from 'commander';
 import * as fs from 'fs/promises';
 import { SendOptions } from '../types/commands';
+import type { SlackMessageBlock } from '../types/slack';
 import { createSlackClient } from '../utils/client-factory';
 import { wrapCommand } from '../utils/command-wrapper';
 import { ERROR_MESSAGES, SUCCESS_MESSAGES } from '../utils/constants';
 import { extractErrorMessage } from '../utils/error-utils';
-import { FileError } from '../utils/errors';
+import { FileError, ValidationError } from '../utils/errors';
 import { parseProfile } from '../utils/option-parsers';
 import { resolvePostAt } from '../utils/schedule-utils';
 import { createValidationHook, optionValidators } from '../utils/validators';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseBlocksJson(blocksJson: string): SlackMessageBlock[] {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(blocksJson);
+  } catch {
+    throw new ValidationError(ERROR_MESSAGES.INVALID_BLOCKS_JSON);
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new ValidationError(ERROR_MESSAGES.INVALID_BLOCKS_SHAPE);
+  }
+
+  const hasInvalidBlock = parsed.some(
+    (block) => !isRecord(block) || typeof block.type !== 'string' || block.type.trim() === ''
+  );
+
+  if (hasInvalidBlock) {
+    throw new ValidationError(ERROR_MESSAGES.INVALID_BLOCK_SHAPE);
+  }
+
+  return parsed as SlackMessageBlock[];
+}
+
+async function readBlocks(options: SendOptions): Promise<SlackMessageBlock[] | undefined> {
+  if (options.blocks !== undefined) {
+    return parseBlocksJson(options.blocks);
+  }
+
+  if (!options.blocksFile) {
+    return undefined;
+  }
+
+  try {
+    const blocksJson = await fs.readFile(options.blocksFile, 'utf-8');
+    return parseBlocksJson(blocksJson);
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      throw error;
+    }
+
+    throw new FileError(
+      ERROR_MESSAGES.FILE_READ_ERROR(options.blocksFile, extractErrorMessage(error))
+    );
+  }
+}
 
 export function setupSendCommand(): Command {
   const sendCommand = new Command('send')
@@ -19,6 +71,8 @@ export function setupSendCommand(): Command {
     .option('--email <email>', 'Send DM to user by email address')
     .option('-m, --message <message>', 'Message to send')
     .option('-f, --file <file>', 'File containing message content')
+    .option('--blocks <json>', 'Block Kit blocks as a JSON array')
+    .option('--blocks-file <file>', 'File containing Block Kit blocks JSON')
     .option('-t, --thread <thread>', 'Thread timestamp to reply to')
     .option('--at <time>', 'Schedule time (Unix timestamp in seconds or ISO 8601)')
     .option('--after <minutes>', 'Schedule message after N minutes')
@@ -35,7 +89,7 @@ export function setupSendCommand(): Command {
     .action(
       wrapCommand(async (options: SendOptions) => {
         // Get message content
-        let messageContent: string;
+        let messageContent: string | undefined;
         if (options.file) {
           try {
             messageContent = await fs.readFile(options.file, 'utf-8');
@@ -45,9 +99,10 @@ export function setupSendCommand(): Command {
             );
           }
         } else {
-          messageContent = options.message!; // This is safe because of preAction validation
+          messageContent = options.message;
         }
 
+        const blocks = await readBlocks(options);
         const postAt = resolvePostAt(options.at, options.after);
 
         // Send message
@@ -72,7 +127,17 @@ export function setupSendCommand(): Command {
         }
 
         if (postAt !== null) {
-          await client.scheduleMessage(targetChannel, messageContent, postAt, options.thread);
+          if (blocks) {
+            await client.scheduleMessage(
+              targetChannel,
+              messageContent,
+              postAt,
+              options.thread,
+              blocks
+            );
+          } else {
+            await client.scheduleMessage(targetChannel, messageContent, postAt, options.thread);
+          }
           const postAtIso = new Date(postAt * 1000).toISOString();
           if (options.user || options.email) {
             console.log(chalk.green(`✓ Message scheduled to ${targetLabel} at ${postAtIso}`));
@@ -84,7 +149,11 @@ export function setupSendCommand(): Command {
           return;
         }
 
-        await client.sendMessage(targetChannel, messageContent, options.thread);
+        if (blocks) {
+          await client.sendMessage(targetChannel, messageContent, options.thread, blocks);
+        } else {
+          await client.sendMessage(targetChannel, messageContent, options.thread);
+        }
         if (options.user || options.email) {
           console.log(chalk.green(`✓ DM sent to ${targetLabel}`));
         } else {

--- a/src/types/commands.ts
+++ b/src/types/commands.ts
@@ -21,6 +21,8 @@ export interface SendOptions {
   email?: string;
   message?: string;
   file?: string;
+  blocks?: string;
+  blocksFile?: string;
   thread?: string;
   at?: string;
   after?: string;

--- a/src/types/slack.ts
+++ b/src/types/slack.ts
@@ -1,6 +1,7 @@
-import type { Block, KnownBlock } from '@slack/types';
-
-export type SlackMessageBlock = KnownBlock | Block;
+export interface SlackMessageBlock {
+  type: string;
+  [key: string]: unknown;
+}
 
 export interface CanvasSectionElement {
   type?: string;

--- a/src/types/slack.ts
+++ b/src/types/slack.ts
@@ -1,3 +1,7 @@
+import type { Block, KnownBlock } from '@slack/types';
+
+export type SlackMessageBlock = KnownBlock | Block;
+
 export interface CanvasSectionElement {
   type?: string;
   text?: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -12,7 +12,12 @@ export const ERROR_MESSAGES = {
 
   // Validation errors
   NO_MESSAGE_OR_FILE: 'You must specify either --message or --file',
+  NO_MESSAGE_FILE_OR_BLOCKS: 'You must specify --message, --file, --blocks, or --blocks-file',
   BOTH_MESSAGE_AND_FILE: 'Cannot use both --message and --file',
+  BOTH_BLOCKS_AND_BLOCKS_FILE: 'Cannot use both --blocks and --blocks-file',
+  INVALID_BLOCKS_JSON: 'Invalid Block Kit blocks JSON',
+  INVALID_BLOCKS_SHAPE: 'Block Kit blocks must be a JSON array',
+  INVALID_BLOCK_SHAPE: 'Each Block Kit block must be an object with a string type',
   INVALID_THREAD_TIMESTAMP: 'Invalid thread timestamp format',
   INVALID_SCHEDULE_AT:
     'Invalid schedule time format. Use Unix timestamp (seconds) or ISO 8601 date-time',

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -22,6 +22,7 @@ import type {
   ScheduledMessage,
   SearchMessagesOptions,
   SearchResult,
+  SlackMessageBlock,
   SlackUser,
   StarListResult,
   UserPresence,
@@ -78,9 +79,14 @@ export class SlackApiClient {
 
   async sendMessage(
     channel: string,
-    text: string,
-    thread_ts?: string
+    text?: string,
+    thread_ts?: string,
+    blocks?: SlackMessageBlock[]
   ): Promise<ChatPostMessageResponse> {
+    if (blocks) {
+      return this.messageOps.sendMessage(channel, text, thread_ts, blocks);
+    }
+
     return this.messageOps.sendMessage(channel, text, thread_ts);
   }
 
@@ -95,10 +101,15 @@ export class SlackApiClient {
 
   async scheduleMessage(
     channel: string,
-    text: string,
+    text: string | undefined,
     post_at: number,
-    thread_ts?: string
+    thread_ts?: string,
+    blocks?: SlackMessageBlock[]
   ): Promise<ChatScheduleMessageResponse> {
+    if (blocks) {
+      return this.messageOps.scheduleMessage(channel, text, post_at, thread_ts, blocks);
+    }
+
     return this.messageOps.scheduleMessage(channel, text, post_at, thread_ts);
   }
 

--- a/src/utils/slack-client-service.ts
+++ b/src/utils/slack-client-service.ts
@@ -83,11 +83,7 @@ export class SlackApiClient {
     thread_ts?: string,
     blocks?: SlackMessageBlock[]
   ): Promise<ChatPostMessageResponse> {
-    if (blocks) {
-      return this.messageOps.sendMessage(channel, text, thread_ts, blocks);
-    }
-
-    return this.messageOps.sendMessage(channel, text, thread_ts);
+    return this.messageOps.sendMessage(channel, text, thread_ts, blocks);
   }
 
   async sendEphemeralMessage(
@@ -106,11 +102,7 @@ export class SlackApiClient {
     thread_ts?: string,
     blocks?: SlackMessageBlock[]
   ): Promise<ChatScheduleMessageResponse> {
-    if (blocks) {
-      return this.messageOps.scheduleMessage(channel, text, post_at, thread_ts, blocks);
-    }
-
-    return this.messageOps.scheduleMessage(channel, text, post_at, thread_ts);
+    return this.messageOps.scheduleMessage(channel, text, post_at, thread_ts, blocks);
   }
 
   async updateMessage(channel: string, ts: string, text: string): Promise<ChatUpdateResponse> {

--- a/src/utils/slack-operations/message-operations.ts
+++ b/src/utils/slack-operations/message-operations.ts
@@ -10,6 +10,7 @@ import type {
   HistoryResult,
   Message,
   ScheduledMessage,
+  SlackMessageBlock,
 } from '../../types/slack';
 import { BaseSlackClient, createSlackClientContext, SlackClientDependency } from './base-client';
 import { ChannelOperations } from './channel-operations';
@@ -42,10 +43,11 @@ export class MessageOperations extends BaseSlackClient {
 
   async sendMessage(
     channel: string,
-    text: string,
-    thread_ts?: string
+    text?: string,
+    thread_ts?: string,
+    blocks?: SlackMessageBlock[]
   ): Promise<ChatPostMessageResponse> {
-    return await this.writeOps.sendMessage(channel, text, thread_ts);
+    return await this.writeOps.sendMessage(channel, text, thread_ts, blocks);
   }
 
   async sendEphemeralMessage(
@@ -59,11 +61,12 @@ export class MessageOperations extends BaseSlackClient {
 
   async scheduleMessage(
     channel: string,
-    text: string,
+    text: string | undefined,
     post_at: number,
-    thread_ts?: string
+    thread_ts?: string,
+    blocks?: SlackMessageBlock[]
   ): Promise<ChatScheduleMessageResponse> {
-    return await this.writeOps.scheduleMessage(channel, text, post_at, thread_ts);
+    return await this.writeOps.scheduleMessage(channel, text, post_at, thread_ts, blocks);
   }
 
   async listScheduledMessages(channel?: string, limit = 50): Promise<ScheduledMessage[]> {

--- a/src/utils/slack-operations/message-write-operations.ts
+++ b/src/utils/slack-operations/message-write-operations.ts
@@ -7,7 +7,7 @@ import {
   ChatScheduleMessageResponse,
   ChatUpdateResponse,
 } from '@slack/web-api';
-import type { ScheduledMessage } from '../../types/slack';
+import type { ScheduledMessage, SlackMessageBlock } from '../../types/slack';
 import { BaseSlackClient, SlackClientDependency } from './base-client';
 import { ChannelOperations } from './channel-operations';
 
@@ -22,13 +22,15 @@ export class MessageWriteOperations extends BaseSlackClient {
 
   async sendMessage(
     channel: string,
-    text: string,
-    thread_ts?: string
+    text?: string,
+    thread_ts?: string,
+    blocks?: SlackMessageBlock[]
   ): Promise<ChatPostMessageResponse> {
-    const params: ChatPostMessageArguments = {
-      channel,
-      text,
-    };
+    const params = (
+      blocks
+        ? { channel, ...(text !== undefined ? { text } : {}), blocks }
+        : { channel, text: text ?? '' }
+    ) as ChatPostMessageArguments;
 
     if (thread_ts) {
       params.thread_ts = thread_ts;
@@ -58,15 +60,16 @@ export class MessageWriteOperations extends BaseSlackClient {
 
   async scheduleMessage(
     channel: string,
-    text: string,
+    text: string | undefined,
     post_at: number,
-    thread_ts?: string
+    thread_ts?: string,
+    blocks?: SlackMessageBlock[]
   ): Promise<ChatScheduleMessageResponse> {
-    const params: ChatScheduleMessageArguments = {
-      channel,
-      text,
-      post_at,
-    };
+    const params = (
+      blocks
+        ? { channel, post_at, ...(text !== undefined ? { text } : {}), blocks }
+        : { channel, text: text ?? '', post_at }
+    ) as ChatScheduleMessageArguments;
 
     if (thread_ts) {
       params.thread_ts = thread_ts;

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -194,14 +194,17 @@ export const optionValidators = {
   },
 
   /**
-   * Validates message/file options for send command
+   * Validates message/file/blocks options for send command
    */
   messageOrFile: (options: Record<string, unknown>): string | null => {
-    if (!options.message && !options.file) {
-      return ERROR_MESSAGES.NO_MESSAGE_OR_FILE;
+    if (!options.message && !options.file && options.blocks === undefined && !options.blocksFile) {
+      return ERROR_MESSAGES.NO_MESSAGE_FILE_OR_BLOCKS;
     }
     if (options.message && options.file) {
       return ERROR_MESSAGES.BOTH_MESSAGE_AND_FILE;
+    }
+    if (options.blocks !== undefined && options.blocksFile) {
+      return ERROR_MESSAGES.BOTH_BLOCKS_AND_BLOCKS_FILE;
     }
     return null;
   },

--- a/tests/commands/send.test.ts
+++ b/tests/commands/send.test.ts
@@ -116,6 +116,141 @@ describe('send command', () => {
     });
   });
 
+  describe('send Block Kit message', () => {
+    it('should send blocks from --blocks with fallback text', async () => {
+      const blocks = [{ type: 'section', text: { type: 'mrkdwn', text: '*Hello*' } }];
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.sendMessage).mockResolvedValue({
+        ok: true,
+        ts: '1234567890.123456',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'send',
+        '-c',
+        'general',
+        '--blocks',
+        JSON.stringify(blocks),
+        '-m',
+        'Hello',
+      ]);
+
+      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
+        'general',
+        'Hello',
+        undefined,
+        blocks
+      );
+    });
+
+    it('should send blocks from --blocks-file without fallback text', async () => {
+      const blocks = [{ type: 'divider' }];
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(blocks));
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.sendMessage).mockResolvedValue({
+        ok: true,
+        ts: '1234567890.123456',
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'send',
+        '-c',
+        'general',
+        '--blocks-file',
+        'blocks.json',
+      ]);
+
+      expect(fs.readFile).toHaveBeenCalledWith('blocks.json', 'utf-8');
+      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
+        'general',
+        undefined,
+        undefined,
+        blocks
+      );
+    });
+
+    it('should schedule blocks from --blocks-file', async () => {
+      const blocks = [{ type: 'divider' }];
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(blocks));
+      vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
+        token: 'test-token',
+        updatedAt: new Date().toISOString(),
+      });
+      vi.mocked(mockSlackClient.scheduleMessage).mockResolvedValue({
+        ok: true,
+        scheduled_message_id: 'Q1298393284',
+        post_at: 2051258400,
+      });
+
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'send',
+        '-c',
+        'general',
+        '--blocks-file',
+        'blocks.json',
+        '--at',
+        '2035-01-01T10:00:00Z',
+      ]);
+
+      expect(mockSlackClient.scheduleMessage).toHaveBeenCalledWith(
+        'general',
+        undefined,
+        2051258400,
+        undefined,
+        blocks
+      );
+      expect(mockSlackClient.sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('should fail when --blocks is not a JSON array', async () => {
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'send',
+        '-c',
+        'general',
+        '--blocks',
+        '{"type":"divider"}',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        'Block Kit blocks must be a JSON array'
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should fail when a block does not have type', async () => {
+      await program.parseAsync([
+        'node',
+        'slack-cli',
+        'send',
+        '-c',
+        'general',
+        '--blocks',
+        '[{"text":"missing type"}]',
+      ]);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        'Each Block Kit block must be an object with a string type'
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+
   describe('send reply to thread', () => {
     it('should send a reply to a thread with --thread option', async () => {
       vi.mocked(mockConfigManager.getConfig).mockResolvedValue({
@@ -312,7 +447,7 @@ describe('send command', () => {
       sendCommand.exitOverride();
 
       await expect(sendCommand.parseAsync(['-c', 'general'], { from: 'user' })).rejects.toThrow(
-        `Error: ${ERROR_MESSAGES.NO_MESSAGE_OR_FILE}`
+        `Error: ${ERROR_MESSAGES.NO_MESSAGE_FILE_OR_BLOCKS}`
       );
     });
 
@@ -325,6 +460,20 @@ describe('send command', () => {
           from: 'user',
         })
       ).rejects.toThrow(`Error: ${ERROR_MESSAGES.BOTH_MESSAGE_AND_FILE}`);
+    });
+
+    it('should fail when both --blocks and --blocks-file are provided', async () => {
+      const sendCommand = setupSendCommand();
+      sendCommand.exitOverride();
+
+      await expect(
+        sendCommand.parseAsync(
+          ['-c', 'general', '--blocks', '[{"type":"divider"}]', '--blocks-file', 'blocks.json'],
+          {
+            from: 'user',
+          }
+        )
+      ).rejects.toThrow(`Error: ${ERROR_MESSAGES.BOTH_BLOCKS_AND_BLOCKS_FILE}`);
     });
 
     it('should fail when both --at and --after are provided', async () => {

--- a/tests/commands/send.test.ts
+++ b/tests/commands/send.test.ts
@@ -232,6 +232,16 @@ describe('send command', () => {
       expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
     });
 
+    it('should fail when --blocks is invalid JSON', async () => {
+      await program.parseAsync(['node', 'slack-cli', 'send', '-c', 'general', '--blocks', '{']);
+
+      expect(mockConsole.errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error:'),
+        ERROR_MESSAGES.INVALID_BLOCKS_JSON
+      );
+      expect(mockConsole.exitSpy).toHaveBeenCalledWith(1);
+    });
+
     it('should fail when a block does not have type', async () => {
       await program.parseAsync([
         'node',

--- a/tests/commands/send.test.ts
+++ b/tests/commands/send.test.ts
@@ -62,6 +62,7 @@ describe('send command', () => {
       expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
         'general',
         'Hello, World!',
+        undefined,
         undefined
       );
       expect(mockConsole.logSpy).toHaveBeenCalledWith(
@@ -112,7 +113,12 @@ describe('send command', () => {
       await program.parseAsync(['node', 'slack-cli', 'send', '-c', 'general', '-f', 'message.txt']);
 
       expect(fs.readFile).toHaveBeenCalledWith('message.txt', 'utf-8');
-      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith('general', fileContent, undefined);
+      expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
+        'general',
+        fileContent,
+        undefined,
+        undefined
+      );
     });
   });
 
@@ -287,7 +293,8 @@ describe('send command', () => {
       expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
         'general',
         'Reply to thread',
-        '1719207629.000100'
+        '1719207629.000100',
+        undefined
       );
       expect(mockConsole.logSpy).toHaveBeenCalledWith(
         expect.stringContaining(SUCCESS_MESSAGES.MESSAGE_SENT('general'))
@@ -319,7 +326,8 @@ describe('send command', () => {
       expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
         'general',
         'Reply to thread',
-        '1719207629.000100'
+        '1719207629.000100',
+        undefined
       );
       expect(mockConsole.logSpy).toHaveBeenCalledWith(
         expect.stringContaining(SUCCESS_MESSAGES.MESSAGE_SENT('general'))
@@ -370,7 +378,8 @@ describe('send command', () => {
       expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
         'general',
         fileContent,
-        '1719207629.000100'
+        '1719207629.000100',
+        undefined
       );
       expect(mockConsole.logSpy).toHaveBeenCalledWith(
         expect.stringContaining(SUCCESS_MESSAGES.MESSAGE_SENT('general'))
@@ -406,6 +415,7 @@ describe('send command', () => {
         'general',
         'Future message',
         2051258400,
+        undefined,
         undefined
       );
       expect(mockSlackClient.sendMessage).not.toHaveBeenCalled();
@@ -444,6 +454,7 @@ describe('send command', () => {
         'general',
         'Future message',
         1770855000,
+        undefined,
         undefined
       );
 
@@ -604,6 +615,7 @@ describe('send command', () => {
       expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
         'D9876543210',
         'Hello via DM!',
+        undefined,
         undefined
       );
       expect(mockConsole.logSpy).toHaveBeenCalledWith(expect.stringContaining('DM sent to @john'));
@@ -656,6 +668,7 @@ describe('send command', () => {
       expect(mockSlackClient.sendMessage).toHaveBeenCalledWith(
         'D9876543210',
         'Hello via email DM!',
+        undefined,
         undefined
       );
       expect(mockConsole.logSpy).toHaveBeenCalledWith(

--- a/tests/utils/slack-api-client.test.ts
+++ b/tests/utils/slack-api-client.test.ts
@@ -122,6 +122,20 @@ describe('SlackApiClient', () => {
       });
     });
 
+    it('should send Block Kit blocks', async () => {
+      const mockResponse = { ok: true, ts: '1234567890.123456' };
+      const blocks = [{ type: 'divider' }];
+      vi.mocked(mockWebClient.chat.postMessage).mockResolvedValue(mockResponse as never);
+
+      const result = await client.sendMessage('general', undefined, undefined, blocks);
+
+      expect(mockWebClient.chat.postMessage).toHaveBeenCalledWith({
+        channel: 'general',
+        blocks,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
     it('should throw error on API failure', async () => {
       const mockError = new Error('channel_not_found');
       vi.mocked(mockWebClient.chat.postMessage).mockRejectedValue(mockError);
@@ -141,6 +155,27 @@ describe('SlackApiClient', () => {
         channel: 'general',
         text: 'Hello, future!',
         post_at: 1770855000,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should schedule Block Kit blocks', async () => {
+      const mockResponse = { ok: true, scheduled_message_id: 'Q123', post_at: 1770855000 };
+      const blocks = [{ type: 'divider' }];
+      vi.mocked(mockWebClient.chat.scheduleMessage).mockResolvedValue(mockResponse as never);
+
+      const result = await client.scheduleMessage(
+        'general',
+        undefined,
+        1770855000,
+        undefined,
+        blocks
+      );
+
+      expect(mockWebClient.chat.scheduleMessage).toHaveBeenCalledWith({
+        channel: 'general',
+        post_at: 1770855000,
+        blocks,
       });
       expect(result).toEqual(mockResponse);
     });

--- a/tests/utils/slack-client-service.test.ts
+++ b/tests/utils/slack-client-service.test.ts
@@ -112,9 +112,15 @@ describe('SlackApiClient service facade', () => {
 
   it('delegates message operations', async () => {
     const { client, ops } = createClientWithOps();
+    const blocks = [{ type: 'divider' }];
 
     await expect(client.sendMessage('C1', 'hello', '1.2')).resolves.toBe('sendMessage-result');
     expect(ops.messageOps.sendMessage).toHaveBeenCalledWith('C1', 'hello', '1.2');
+
+    await expect(client.sendMessage('C1', undefined, undefined, blocks)).resolves.toBe(
+      'sendMessage-result'
+    );
+    expect(ops.messageOps.sendMessage).toHaveBeenCalledWith('C1', undefined, undefined, blocks);
 
     await expect(client.sendEphemeralMessage('C1', 'U1', 'hello', '1.2')).resolves.toBe(
       'sendEphemeralMessage-result'
@@ -125,6 +131,17 @@ describe('SlackApiClient service facade', () => {
       'scheduleMessage-result'
     );
     expect(ops.messageOps.scheduleMessage).toHaveBeenCalledWith('C1', 'later', 123, '1.2');
+
+    await expect(client.scheduleMessage('C1', undefined, 123, undefined, blocks)).resolves.toBe(
+      'scheduleMessage-result'
+    );
+    expect(ops.messageOps.scheduleMessage).toHaveBeenCalledWith(
+      'C1',
+      undefined,
+      123,
+      undefined,
+      blocks
+    );
 
     await expect(client.updateMessage('C1', '1.2', 'updated')).resolves.toBe(
       'updateMessage-result'

--- a/tests/utils/slack-client-service.test.ts
+++ b/tests/utils/slack-client-service.test.ts
@@ -115,7 +115,7 @@ describe('SlackApiClient service facade', () => {
     const blocks = [{ type: 'divider' }];
 
     await expect(client.sendMessage('C1', 'hello', '1.2')).resolves.toBe('sendMessage-result');
-    expect(ops.messageOps.sendMessage).toHaveBeenCalledWith('C1', 'hello', '1.2');
+    expect(ops.messageOps.sendMessage).toHaveBeenCalledWith('C1', 'hello', '1.2', undefined);
 
     await expect(client.sendMessage('C1', undefined, undefined, blocks)).resolves.toBe(
       'sendMessage-result'
@@ -130,7 +130,13 @@ describe('SlackApiClient service facade', () => {
     await expect(client.scheduleMessage('C1', 'later', 123, '1.2')).resolves.toBe(
       'scheduleMessage-result'
     );
-    expect(ops.messageOps.scheduleMessage).toHaveBeenCalledWith('C1', 'later', 123, '1.2');
+    expect(ops.messageOps.scheduleMessage).toHaveBeenCalledWith(
+      'C1',
+      'later',
+      123,
+      '1.2',
+      undefined
+    );
 
     await expect(client.scheduleMessage('C1', undefined, 123, undefined, blocks)).resolves.toBe(
       'scheduleMessage-result'

--- a/tests/utils/slack-operations/message-write-operations.test.ts
+++ b/tests/utils/slack-operations/message-write-operations.test.ts
@@ -63,6 +63,28 @@ describe('MessageWriteOperations', () => {
     });
   });
 
+  it('sends Block Kit messages', async () => {
+    const blocks = [{ type: 'divider' }];
+    mockClient.chat.postMessage.mockResolvedValue({ ok: true, ts: '1.2' });
+
+    await expect(messageOps.sendMessage('C1', 'fallback', undefined, blocks)).resolves.toEqual({
+      ok: true,
+      ts: '1.2',
+    });
+    expect(mockClient.chat.postMessage).toHaveBeenCalledWith({
+      channel: 'C1',
+      text: 'fallback',
+      blocks,
+    });
+
+    await messageOps.sendMessage('C1', undefined, '1.2', blocks);
+    expect(mockClient.chat.postMessage).toHaveBeenLastCalledWith({
+      channel: 'C1',
+      blocks,
+      thread_ts: '1.2',
+    });
+  });
+
   it('sends regular and threaded ephemeral messages', async () => {
     mockClient.chat.postEphemeral.mockResolvedValue({ ok: true });
 
@@ -98,6 +120,19 @@ describe('MessageWriteOperations', () => {
       text: 'thread later',
       post_at: 123,
       thread_ts: '1.2',
+    });
+  });
+
+  it('schedules Block Kit messages', async () => {
+    const blocks = [{ type: 'divider' }];
+    mockClient.chat.scheduleMessage.mockResolvedValue({ ok: true, scheduled_message_id: 'Q1' });
+
+    await messageOps.scheduleMessage('C1', undefined, 123, undefined, blocks);
+
+    expect(mockClient.chat.scheduleMessage).toHaveBeenCalledWith({
+      channel: 'C1',
+      post_at: 123,
+      blocks,
     });
   });
 

--- a/tests/utils/validators.test.ts
+++ b/tests/utils/validators.test.ts
@@ -221,9 +221,17 @@ describe('validators', () => {
         expect(optionValidators.messageOrFile({ file: 'path.txt' })).toBeNull();
       });
 
+      it('should pass when blocks are provided', () => {
+        expect(optionValidators.messageOrFile({ blocks: '[{"type":"divider"}]' })).toBeNull();
+      });
+
+      it('should pass when blocks file is provided', () => {
+        expect(optionValidators.messageOrFile({ blocksFile: 'blocks.json' })).toBeNull();
+      });
+
       it('should fail when neither is provided', () => {
         expect(optionValidators.messageOrFile({})).toBe(
-          'You must specify either --message or --file'
+          'You must specify --message, --file, --blocks, or --blocks-file'
         );
       });
 
@@ -231,6 +239,15 @@ describe('validators', () => {
         expect(optionValidators.messageOrFile({ message: 'text', file: 'path.txt' })).toBe(
           'Cannot use both --message and --file'
         );
+      });
+
+      it('should fail when both blocks sources are provided', () => {
+        expect(
+          optionValidators.messageOrFile({
+            blocks: '[{"type":"divider"}]',
+            blocksFile: 'blocks.json',
+          })
+        ).toBe('Cannot use both --blocks and --blocks-file');
       });
     });
 


### PR DESCRIPTION
# 背景

- `slack-cli send` からSlackのBlock Kit形式でメッセージを送信できるようにするための変更です。

# 概要

- `send` コマンドに `--blocks` と `--blocks-file` を追加しました。
- Block Kit blocksはJSON配列で、各要素が文字列の `type` を持つobjectであることを送信前に検証します。
- `-m` / `-f` はblocksと併用した場合、Slack通知用のfallback textとして送信します。
- 通常送信、スレッド返信、予約送信でblocksをSlack API payloadへ渡せるようにしました。
- package versionを `0.27.0` に更新しました。

# 確認方法

- `npm run check`
- `npm run build`
- `npm test -- --run`
- `npm run test:coverage`
