### PR TITLE
fix: include blocks and attachments in JSON history output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@urugus/slack-cli",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "MIT",
       "dependencies": {
         "@slack/web-api": "7.16.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@urugus/slack-cli",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "A command-line tool for sending messages to Slack",
   "main": "dist/index.js",
   "bin": {
     "slack-cli": "dist/index.js"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "ts-node src/index.ts",
@@ -22,7 +24,13 @@
     "check:fix": "biome check --write .",
     "prepublishOnly": "npm run build"
   },
-  "keywords": ["slack", "cli", "command-line", "messaging", "api"],
+  "keywords": [
+    "slack",
+    "cli",
+    "command-line",
+    "messaging",
+    "api"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/urugus/slack-cli.git"

--- a/src/utils/formatters/history-formatters.ts
+++ b/src/utils/formatters/history-formatters.ts
@@ -93,6 +93,8 @@ class JsonHistoryFormatter extends JsonFormatter<HistoryFormatterOptions> {
       channel: channelName,
       messages: messages.map((message) => {
         const files = message.files ?? [];
+        const blocks = message.blocks ?? [];
+        const attachments = message.attachments ?? [];
 
         return {
           ts: message.ts,
@@ -102,6 +104,8 @@ class JsonHistoryFormatter extends JsonFormatter<HistoryFormatterOptions> {
           ...(message.thread_ts !== undefined && { thread_ts: message.thread_ts }),
           ...(message.reply_count !== undefined && { reply_count: message.reply_count }),
           ...(files.length > 0 ? { files: files.map(formatFile) } : {}),
+          ...(blocks.length > 0 ? { blocks } : {}),
+          ...(attachments.length > 0 ? { attachments } : {}),
           ...(permalinks?.has(message.ts) && { permalink: permalinks.get(message.ts) }),
         };
       }),

--- a/tests/utils/formatters/history-formatters.test.ts
+++ b/tests/utils/formatters/history-formatters.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Message } from '../../../src/types/slack';
+import {
+  createHistoryFormatter,
+  HistoryFormatterOptions,
+} from '../../../src/utils/formatters/history-formatters';
+
+describe('JsonHistoryFormatter', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  const baseMessage: Message = {
+    type: 'message',
+    ts: '1700000000.000000',
+    text: 'Hello world',
+    user: 'U123',
+  };
+
+  const createOptions = (messages: Message[]): HistoryFormatterOptions => ({
+    channelName: 'general',
+    messages,
+    users: new Map([['U123', 'testuser']]),
+  });
+
+  const capturedJson = (): { messages: Array<Record<string, unknown>> } => {
+    const call = consoleSpy.mock.calls.find(
+      (args) => typeof args[0] === 'string' && args[0].startsWith('{')
+    );
+    expect(call, 'expected JSON output via console.log').toBeTruthy();
+    return JSON.parse(call?.[0] as string);
+  };
+
+  describe('blocks / attachments passthrough', () => {
+    it('should include blocks field when message has blocks', () => {
+      const message: Message = {
+        ...baseMessage,
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'block body' } }],
+      };
+
+      const formatter = createHistoryFormatter('json');
+      formatter.format(createOptions([message]));
+
+      const parsed = capturedJson();
+      expect(parsed.messages).toHaveLength(1);
+      expect(parsed.messages[0]).toHaveProperty('blocks');
+      expect(parsed.messages[0].blocks).toEqual(message.blocks);
+    });
+
+    it('should include attachments field when message has attachments', () => {
+      const message: Message = {
+        ...baseMessage,
+        attachments: [{ id: 1, fallback: 'fallback', text: 'attachment body' }],
+      };
+
+      const formatter = createHistoryFormatter('json');
+      formatter.format(createOptions([message]));
+
+      const parsed = capturedJson();
+      expect(parsed.messages[0]).toHaveProperty('attachments');
+      expect(parsed.messages[0].attachments).toEqual(message.attachments);
+    });
+
+    it('should omit blocks when message has empty blocks array', () => {
+      const message: Message = { ...baseMessage, blocks: [] };
+
+      const formatter = createHistoryFormatter('json');
+      formatter.format(createOptions([message]));
+
+      const parsed = capturedJson();
+      expect(parsed.messages[0]).not.toHaveProperty('blocks');
+    });
+
+    it('should omit attachments when message has empty attachments array', () => {
+      const message: Message = { ...baseMessage, attachments: [] };
+
+      const formatter = createHistoryFormatter('json');
+      formatter.format(createOptions([message]));
+
+      const parsed = capturedJson();
+      expect(parsed.messages[0]).not.toHaveProperty('attachments');
+    });
+
+    it('should include both blocks and attachments when present', () => {
+      const message: Message = {
+        ...baseMessage,
+        blocks: [{ type: 'section', text: { type: 'mrkdwn', text: 'b' } }],
+        attachments: [{ id: 1, fallback: 'f' }],
+      };
+
+      const formatter = createHistoryFormatter('json');
+      formatter.format(createOptions([message]));
+
+      const parsed = capturedJson();
+      expect(parsed.messages[0].blocks).toEqual(message.blocks);
+      expect(parsed.messages[0].attachments).toEqual(message.attachments);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

`history --format json` (and the JSON output for the thread / message
fetches that share the same formatter) silently drops `blocks` and
`attachments` from each message in `JsonHistoryFormatter.transform()`.

Slack's `conversations.history` and `conversations.replies` return both
fields by default, but the formatter only forwards `ts`, `timestamp`,
`user`, `text`, `thread_ts`, `reply_count`, `files`, and `permalink`.
For messages built with Block Kit (most app/bot posts), the body lives
in `blocks`. The `text` field is a fallback summary intended for
notifications and accessibility, and bots often leave it empty or set
it to a single header line. As a result, JSON consumers see an empty /
truncated message even though Slack itself renders it fully.

I hit this in practice while reading a bot reply with this CLI: the
bot used multiple `section` blocks for the body and ~30 chars in the
`text` field. From the CLI, the message looked truncated.

## Change

Include `blocks` and `attachments` in the per-message transform when
non-empty, mirroring the existing handling of `files`. Empty arrays
are still omitted to keep the output shape stable for messages that
don't carry them.

The Slack types already declare both fields on `Message` in
`src/types/slack.ts`, so no type changes are required. The underlying
`MessageHistoryOperations` already passes through the raw `messages`
array, so the data is already in hand — this PR only stops the
formatter from dropping it.

## Tests

Added `tests/utils/formatters/history-formatters.test.ts` covering:

- `blocks` field present when the message has blocks
- `attachments` field present when the message has attachments
- both fields present together
- `blocks` omitted when the message carries an empty `blocks` array
- `attachments` omitted when the message carries an empty `attachments` array

All 5 new tests pass. Pre-existing test failures (`tests/index.test.ts`,
`tests/utils/profile-config.test.ts`, `tests/utils/token-crypto-service.test.ts`,
`tests/utils/update-notifier.test.ts`, `tests/utils/slack-operations/file-operations.test.ts`)
are unrelated to this change — I confirmed on `main` that they fail
identically without this branch.

## Version

Bumps `package.json` from `0.27.0` to `0.27.1` (patch) since this is a
bug fix in an existing output format with no breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)